### PR TITLE
Initial work on #224

### DIFF
--- a/gm.so/include/worker.h
+++ b/gm.so/include/worker.h
@@ -72,6 +72,8 @@ class Worker : public rvs::ThreadBase {
   void set_log_int(int interval) { log_interval = interval; }
   //! sets terminate key
   void set_terminate(bool term_true) { term = term_true; }
+  //! sets force key
+  void set_force(bool flag) { force = flag; }
   //! sets true/false for metric
   void set_metr_mon(std::string metr_name, bool metr_true);
   //! sets bound values for metric
@@ -110,6 +112,8 @@ class Worker : public rvs::ThreadBase {
   int log_interval;
   //! terminate key
   bool term;
+  //! force key
+  bool force;
   //! number of times of get metric
   int count;
 //! gpu_id and average metrics values

--- a/gm.so/src/action.cpp
+++ b/gm.so/src/action.cpp
@@ -127,6 +127,8 @@ int action::run(void) {
       pworker->set_sample_int(sample_interval);
       pworker->set_log_int(log_interval);
       pworker->set_terminate(terminate);
+      if (property["force"] == "true")
+        pworker->set_force(true);
 
       if (rvs::actionbase::has_property("duration")) {
         rvs::actionbase::property_get_run_duration(&error);

--- a/gm.so/src/worker.cpp
+++ b/gm.so/src/worker.cpp
@@ -30,6 +30,7 @@ all
 #include "worker.h"
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include <map>
 #include <string>
@@ -100,6 +101,7 @@ static bool GetMonitorDevices(const std::shared_ptr<amd::smi::Device> &d,
 
 Worker::Worker() {
   bfiltergpu = false;
+  force = false;
   auto metric_length = std::end(metric_names) - std::begin(metric_names);
     for (int i = 0; i < metric_length; i++) {
         bounds.insert(std::pair<string, Metric_bound>(metric_names[i],
@@ -377,7 +379,15 @@ void Worker::run() {
               log(msg.c_str(), rvs::loginfo);
               met_violation[val_str].mem_clock_violation++;
               if (term) {
-                // exit
+                if (force) {
+                  // stop logging
+                  rvs::lp::Stop(1);
+                  // force exit
+                  exit(EXIT_FAILURE);
+                } else {
+                  // just signal stop processing
+                  rvs::lp::Stop(0);
+                }
                 brun = false;
                 break;
               }
@@ -411,7 +421,15 @@ void Worker::run() {
               log(msg.c_str(), rvs::loginfo);
               met_violation[val_str].clock_violation++;
               if (term) {
-                // exit
+                if (force) {
+                  // stop logging
+                  rvs::lp::Stop(1);
+                  // force exit
+                  exit(EXIT_FAILURE);
+                } else {
+                  // just signal stop processing
+                  rvs::lp::Stop(0);
+                }
                 brun = false;
                 break;
               }
@@ -442,7 +460,15 @@ void Worker::run() {
             log(msg.c_str(), rvs::loginfo);
             met_violation[val_str].temp_violation++;
             if (term) {
-              // exit
+              if (force) {
+                // stop logging
+                rvs::lp::Stop(1);
+                // force exit
+                exit(EXIT_FAILURE);
+              } else {
+                // just signal stop processing
+                rvs::lp::Stop(0);
+              }
               brun = false;
               break;
             }
@@ -476,7 +502,15 @@ void Worker::run() {
               log(msg.c_str(), rvs::loginfo);
               met_violation[val_str].fan_violation++;
               if (term) {
-                // exit
+                if (force) {
+                  // stop logging
+                  rvs::lp::Stop(1);
+                  // force exit
+                  exit(EXIT_FAILURE);
+                } else {
+                  // just signal stop processing
+                  rvs::lp::Stop(0);
+                }
                 brun = false;
                 break;
               }
@@ -506,7 +540,15 @@ void Worker::run() {
               log(msg.c_str(), rvs::loginfo);
               met_violation[val_str].power_violation++;
               if (term) {
-                // exit
+                if (force) {
+                  // stop logging
+                  rvs::lp::Stop(1);
+                  // force exit
+                  exit(EXIT_FAILURE);
+                } else {
+                  // just signal stop processing
+                  rvs::lp::Stop(0);
+                }
                 brun = false;
                 break;
               }

--- a/include/rvsliblog.h
+++ b/include/rvsliblog.h
@@ -25,6 +25,7 @@
 #ifndef INCLUDE_RVSLIBLOG_H_
 #define INCLUDE_RVSLIBLOG_H_
 
+#include "stdint.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +43,8 @@ typedef void* (*t_cbCreateNode)(void* Parent, const char* Name);
 typedef void  (*t_cbAddString)(void* Parent, const char* Key, const char* Val);
 typedef void  (*t_cbAddInt)(void* Parent, const char* Key, const int Val);
 typedef void  (*t_cbAddNode)(void* Parent, void* Child);
+typedef void  (*t_cbStop)(uint16_t flags);
+typedef bool  (*t_cbStopping)(void);
 
 /**
  * @brief Module initialization structure
@@ -63,6 +66,10 @@ typedef struct tag_module_init {
   t_cbAddInt           cbAddInt;
   //! pointer to rvs::logger::AddNode() function
   t_cbAddNode          cbAddNode;
+  //! pointer to rvs::logger::Stop() function
+  t_cbStop             cbStop;
+  //! pointer to rvs::logger::Stopping() function
+  t_cbStopping         cbStopping;
 } T_MODULE_INIT;
 
 #ifdef __cplusplus

--- a/include/rvsliblogger.h
+++ b/include/rvsliblogger.h
@@ -70,6 +70,8 @@ class logger {
   static  void   AddNode(void* Parent, void* Child);
   static  int    ToFile(const std::string& Row);
   static  int    JsonPatchAppend(void);
+  static  void   Stop(uint16_t flags);
+  static  bool   Stopping(void);
 
  protected:
   //! Current logging level (0..5)
@@ -86,6 +88,10 @@ class logger {
   static std::mutex cout_mutex;
   //! Mutex to synchronize log file output
   static std::mutex log_mutex;
+  //! flag indicating stop loging was requested
+  static bool bStop;
+  //! stop flags
+  static uint16_t stop_flags;
 };
 
 }  // namespace rvs

--- a/include/rvsloglp.h
+++ b/include/rvsloglp.h
@@ -66,7 +66,8 @@ class lp {
   static void  AddInt(void* Parent, const char* Key, const int Val);
   static void  AddNode(void* Parent, void* Child);
   static bool  get_ticks(unsigned int* psec, unsigned int* pusec);
-
+  static void  Stop(uint16_t flags);
+  static bool  Stopping();
 
  protected:
   //! Module init structure passed through Initialize() method

--- a/rvs/conf/gm21.conf
+++ b/rvs/conf/gm21.conf
@@ -1,0 +1,41 @@
+# GM test #1
+#
+# Preconditions:
+#   Set device to all
+#   Set some metrics and its bounds
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/gm1.conf
+#
+# Expected result:
+#   Test passes with displaying input metric data for any GPUs
+
+actions:
+- name: action_1
+  module: gm
+  device: all
+  monitor: true
+  metrics:
+    temp: true 33 0
+    fan: true 10 0
+  terminate: true
+  force: true
+- name: action_2
+  device: 33367
+  module: gst
+  parallel: false
+  count: 2
+  wait: 100
+  duration: 18000
+  ramp_interval: 7000
+  log_interval: 1000
+  max_violations: 1
+  copy_matrix: false
+  target_stress: 5000
+  tolerance: 0.07
+  matrix_size: 5760
+- name: action_3
+  module: gm
+  device: all
+  monitor: true

--- a/rvs/src/rvsexec_do_yaml.cpp
+++ b/rvs/src/rvsexec_do_yaml.cpp
@@ -75,6 +75,11 @@ int rvs::exec::do_yaml(const std::string& config_file) {
   for (YAML::const_iterator it = actions.begin(); it != actions.end(); ++it) {
     const YAML::Node& action = *it;
 
+    // if stop was requested
+    if (rvs::logger::Stopping()) {
+      return -1;
+    }
+
     // find module name
     std::string rvsmodule = action["module"].as<std::string>();
 

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -223,6 +223,8 @@ int rvs::module::initialize() {
   d.cbAddString       = rvs::logger::AddString;
   d.cbAddInt          = rvs::logger::AddInt;
   d.cbAddNode         = rvs::logger::AddNode;
+  d.cbStop            = rvs::logger::Stop;
+  d.cbStopping        = rvs::logger::Stopping;
 
   return (*rvs_module_init)(reinterpret_cast<void*>(&d));
 }

--- a/src/rvsliblogger.cpp
+++ b/src/rvsliblogger.cpp
@@ -50,6 +50,8 @@ bool  rvs::logger::append_m;
 bool  rvs::logger::isfirstrecord_m;
 std::mutex  rvs::logger::cout_mutex;
 std::mutex  rvs::logger::log_mutex;
+bool  rvs::logger::bStop;
+uint16_t rvs::logger::stop_flags;
 
 const char*  rvs::logger::loglevelname[] = {
   "NONE  ", "RESULT", "ERROR ", "INFO  ", "DEBUG ", "TRACE " };
@@ -170,6 +172,14 @@ int rvs::logger::LogExt(const char* Message, const int LogLevel,
                         const unsigned int Sec, const unsigned int uSec) {
   // lock cout_mutex for the duration of this block
   std::lock_guard<std::mutex> lk(cout_mutex);
+
+  // stop logging requested?
+  if (bStop) {
+    if (stop_flags)
+      // just return
+      return 0;
+  }
+
   if (LogLevel < lognone || LogLevel > logtrace) {
     cerr << "ERROR: unknown logging level: " << LogLevel << '\n';
     return -1;
@@ -321,6 +331,11 @@ int rvs::logger::ToFile(const std::string& Row) {
   // lock log_mutex for the duration of this block
   std::lock_guard<std::mutex> lk(log_mutex);
 
+  if (bStop) {
+    if (stop_flags)
+      return 0;
+  }
+
   std::string logfile;
   if (!rvs::options::has_option("-l", &logfile))
     return -1;
@@ -431,6 +446,8 @@ void  rvs::logger::AddNode(void* Parent, void* Child) {
  */
 int rvs::logger::initialize() {
   isfirstrecord_m = true;
+  bStop = false;
+  stop_flags = 0;
 
   std::string row;
   std::string logfile;
@@ -487,4 +504,38 @@ int rvs::logger::terminate() {
   ToFile(row);
 
   return 0;
+}
+
+/**
+ * @brief Signals that RVS is about to terminate.
+ *
+ * This method will prevent all further
+ * printout to cout and to log file if any. Log file will be closed and properly
+ * terminated before returning from this function.
+ *
+ */
+void rvs::logger::Stop(uint16_t flags) {
+  // lock cout_mutex for the duration of this block
+  std::lock_guard<std::mutex> lk(cout_mutex);
+
+  // signal no further logging to either screen or file
+  bStop = true;
+  stop_flags = flags;
+
+  // properly terminate log file if needed
+  terminate();
+}
+
+/**
+ * @brief Returns stop flag
+ *
+ * Checks if a module requested RVS processing to stop
+ *
+ */
+bool rvs::logger::Stopping(void) {
+  // lock cout_mutex for the duration of this block
+  std::lock_guard<std::mutex> lk(cout_mutex);
+
+  // return stop flag
+  return bStop;
 }

--- a/src/rvsloglp.cpp
+++ b/src/rvsloglp.cpp
@@ -48,6 +48,8 @@ int   rvs::lp::Initialize(const T_MODULE_INIT* pMi) {
   mi.cbAddString       = pMi->cbAddString;
   mi.cbAddInt          = pMi->cbAddInt;
   mi.cbAddNode         = pMi->cbAddNode;
+  mi.cbStop            = pMi->cbStop;
+  mi.cbStopping        = pMi->cbStopping;
 
   return 0;
 }
@@ -248,4 +250,26 @@ bool rvs::lp::get_ticks(unsigned int* psecs, unsigned int* pusecs) {
   *psecs  = ts.tv_sec;
 
   return true;
+}
+
+/**
+ * @brief Signals that RVS is about to terminate.
+ *
+ * This method will prevent all further
+ * printout to cout and to log file if any. Log file will be closed and properly
+ * terminated before returning from this function.
+ *
+ */
+void  rvs::lp::Stop(uint16_t flags) {
+  (*mi.cbStop)(flags);
+}
+
+/**
+ * @brief Returns stop flag
+ *
+ * Checks if a module requested RVS processing to stop
+ *
+ */
+bool  rvs::lp::Stopping() {
+  return (*mi.cbStopping)();
 }


### PR DESCRIPTION
Preliminary fix. Use new keyword "force" to let GM actin force terminate the process. This will kill all threads and generally may result in resource leaks. Also, it throws ugly stack dump onto screen...

test: `sudo ./rvs -c conf/gm21.conf -d 3`

Provision is made for graceful exit, but this require cooperation from all worker threads in other RVS modules (not yet implemented)