### PR TITLE
IET - added support for rvs::lp::Stopping()

### DIFF
--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -487,6 +487,10 @@ bool action::do_edp_test(void) {
             for (i = 0; i < edpp_gpus.size(); i++) {
                 workers[i].start();
                 workers[i].join();
+
+                // check if stop signal was received
+                if (rvs::lp::Stopping())
+                    break;
             }
         }
 
@@ -496,7 +500,7 @@ bool action::do_edp_test(void) {
                 break;
         }
     }
-    return true;
+    return rvs::lp::Stopping() ? false : true;
 }
 
 /**

--- a/iet.so/src/blas_worker.cpp
+++ b/iet.so/src/blas_worker.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 
 #include "rvs_blas.h"
+#include "rvsloglp.h"
 
 #define IET_MEM_ALLOC_ERROR                     1
 #define IET_BLAS_ERROR                          2
@@ -250,6 +251,10 @@ void blas_worker::run() {
                 usleep_ex(sgemm_delay);
             }
         }
+
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            break;
     }
 }
 

--- a/iet.so/src/log_worker.cpp
+++ b/iet.so/src/log_worker.cpp
@@ -142,6 +142,10 @@ void log_worker::run() {
 
     start_time = std::chrono::system_clock::now();
     for (;;) {
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            break;
+
         {
             std::lock_guard<std::mutex> lck(mtx_brun);
             if (!brun)

--- a/rvs/conf/gmiet.conf
+++ b/rvs/conf/gmiet.conf
@@ -1,0 +1,41 @@
+# GM test #1
+#
+# Preconditions:
+#   Set device to all
+#   Set some metrics and its bounds
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/gm1.conf
+#
+# Expected result:
+#   Test passes with displaying input metric data for any GPUs
+
+actions:
+- name: action_1
+  module: gm
+  device: all
+  monitor: true
+  metrics:
+    temp: true 32 0
+    fan: true 10 0
+  terminate: true
+  force: true
+- name: action_2
+  device: all
+  module: iet
+  parallel: false
+  count: 2
+  wait: 100
+  duration: 10000
+  ramp_interval: 5000
+  sample_interval: 500
+  log_interval: 500
+  max_violations: 1
+  target_power: 135
+  tolerance: 0.1
+  matrix_size: 5760
+- name: action_3
+  module: gm
+  device: all
+  monitor: true


### PR DESCRIPTION
changes:
added support for IET's threads gracefully exit

how to run
sudo bin/rvs -c bin/conf/gmiet.conf -d 3

P.S. gmiet.conf shows how the IET module gracefully terminates its execution when the GM module detects that the GPU's temperature violates the bounds (sometimes it can only be seen on the 2nd run, depending on how fast the GPU gets warm)  
