### PR TITLE
Iss237 - GST rvs:lp::Stopping() functionality

### DIFF
--- a/gst.so/src/action.cpp
+++ b/gst.so/src/action.cpp
@@ -289,7 +289,7 @@ bool action::do_gpu_stress_test(map<int, uint16_t> gst_gpus_device_index) {
 
                 // check if stop signal was received
                 if (rvs::lp::Stopping())
-                    break;
+                    return false;
             }
         }
 

--- a/gst.so/src/action.cpp
+++ b/gst.so/src/action.cpp
@@ -286,6 +286,10 @@ bool action::do_gpu_stress_test(map<int, uint16_t> gst_gpus_device_index) {
             for (i = 0; i < gst_gpus_device_index.size(); i++) {
                 workers[i].start();
                 workers[i].join();
+
+                // check if stop signal was received
+                if (rvs::lp::Stopping())
+                    break;
             }
         }
 
@@ -295,7 +299,8 @@ bool action::do_gpu_stress_test(map<int, uint16_t> gst_gpus_device_index) {
                 break;
         }
     }
-    return true;
+
+    return rvs::lp::Stopping() ? false : true;
 }
 
 /**

--- a/gst.so/src/gst_worker.cpp
+++ b/gst.so/src/gst_worker.cpp
@@ -493,6 +493,10 @@ void GSTWorker::run() {
                     rvs::loginfo);
         if (run_duration_ms > 0) {
             gst_test_passed = do_gst_stress_test(&error, &err_description);
+            // check if stop signal was received
+            if (rvs::lp::Stopping())
+                return;
+
             if (error) {
                 // GPU didn't complete the test (HIP/rocBlas error(s) occurred)
                 string msg = "[" + action_name + "] " + MODULE_NAME + " " +
@@ -501,10 +505,6 @@ void GSTWorker::run() {
                 log_to_json("err", err_description, rvs::logerror);
                 return;
             }
-
-            // check if stop signal was received
-            if (rvs::lp::Stopping())
-                return;
         }
     }
 

--- a/gst.so/src/gst_worker.cpp
+++ b/gst.so/src/gst_worker.cpp
@@ -119,6 +119,10 @@ void GSTWorker::hit_max_gflops(int *error, string *err_description) {
     gst_log_interval_time = std::chrono::system_clock::now();
 
     for (;;) {
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            break;
+
         gst_end_time = std::chrono::system_clock::now();
         if (time_diff(gst_end_time, gst_start_time) >=
                             NMAX_MS_GPU_RUN_PEAK_PERFORMANCE)
@@ -199,6 +203,10 @@ bool GSTWorker::do_gst_ramp(int *error, string *err_description) {
     if (*error)
         return false;
 
+    // check if stop signal was received
+    if (rvs::lp::Stopping())
+        return false;
+
     // stage 3. reduce the SGEMM frequency and try to achieve the desired Gflops
     // the delay which gives the SGEMM frequency will be dynamically computed
     delay_target_stress = 0;
@@ -208,6 +216,10 @@ bool GSTWorker::do_gst_ramp(int *error, string *err_description) {
     gst_start_gflops_time = std::chrono::system_clock::now();
 
     for (;;) {
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            return false;
+
         gst_end_time = std::chrono::system_clock::now();
         if (time_diff(gst_end_time,  gst_start_time) >
                             ramp_interval - NMAX_MS_GPU_RUN_PEAK_PERFORMANCE)
@@ -363,6 +375,10 @@ bool GSTWorker::do_gst_stress_test(int *error, std::string *err_description) {
     gst_log_interval_time = std::chrono::system_clock::now();
 
     for (;;) {
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            return false;
+
         if (copy_matrix) {
             // copy matrix before each GEMM
             if (!gpu_blas->copy_data_to_gpu()) {
@@ -454,6 +470,10 @@ void GSTWorker::run() {
     }
 
     if (!ramp_up_success) {
+        // check if stop signal was received
+        if (rvs::lp::Stopping())
+            return;
+
         // the selected GPU was not able to achieve the target_stress GFLOPS
         msg = "[" + action_name + "] " + MODULE_NAME + " " +
                 std::to_string(gpu_id) + " " + GST_RAMP_EXCEEDED_MSG + " " +
@@ -481,6 +501,10 @@ void GSTWorker::run() {
                 log_to_json("err", err_description, rvs::logerror);
                 return;
             }
+
+            // check if stop signal was received
+            if (rvs::lp::Stopping())
+                return;
         }
     }
 

--- a/rvs/conf/gmgst1.conf
+++ b/rvs/conf/gmgst1.conf
@@ -1,0 +1,37 @@
+# GM test #1
+#
+# Preconditions:
+#   Set device to all
+#   Set some metrics and its bounds
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/gm1.conf
+#
+# Expected result:
+#   Test passes with displaying input metric data for any GPUs
+
+actions:
+- name: action_1
+  module: gm
+  device: all
+  monitor: true
+  metrics:
+    temp: true 33 0
+    fan: true 10 0
+  terminate: true
+  force: true
+- name: action_2
+  device: 33367
+  module: gst
+  parallel: false
+  count: 2
+  wait: 100
+  duration: 18000
+  ramp_interval: 7000
+  log_interval: 1000
+  max_violations: 1
+  copy_matrix: false
+  target_stress: 5000
+  tolerance: 0.07
+  matrix_size: 5760

--- a/rvs/conf/gmgst1.conf
+++ b/rvs/conf/gmgst1.conf
@@ -20,7 +20,6 @@ actions:
     temp: true 33 0
     fan: true 10 0
   terminate: true
-  force: true
 - name: action_2
   device: 33367
   module: gst

--- a/rvs/conf/gmgst2.conf
+++ b/rvs/conf/gmgst2.conf
@@ -1,0 +1,37 @@
+# GM test #1
+#
+# Preconditions:
+#   Set device to all
+#   Set some metrics and its bounds
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/gm1.conf
+#
+# Expected result:
+#   Test passes with displaying input metric data for any GPUs
+
+actions:
+- name: action_1
+  module: gm
+  device: all
+  monitor: true
+  metrics:
+    temp: true 50 0
+    fan: true 10 0
+  terminate: true
+  force: true
+- name: action_2
+  device: 33367
+  module: gst
+  parallel: false
+  count: 2
+  wait: 100
+  duration: 18000
+  ramp_interval: 7000
+  log_interval: 1000
+  max_violations: 1
+  copy_matrix: false
+  target_stress: 5000
+  tolerance: 0.07
+  matrix_size: 5760

--- a/rvs/conf/gmgst2.conf
+++ b/rvs/conf/gmgst2.conf
@@ -20,7 +20,6 @@ actions:
     temp: true 50 0
     fan: true 10 0
   terminate: true
-  force: true
 - name: action_2
   device: 33367
   module: gst


### PR DESCRIPTION
changes:
added support for GST's threads gracefully exit

how to run
sudo bin/rvs -c bin/conf/gmgst1.conf -d 3
sudo bin/rvs -c bin/conf/gmgst2.conf -d 3

P.S. 
- gmgst1.conf shows how the GST module gracefully terminates its execution when the GM module detects that the GPU's temperature violates the bounds (sometimes it can only be seen on the 2nd run, depending on how fast the GPU gets warm)
- gmgst2.conf should not cause RVS  to terminate due to temperature violation (max temperature is bigger)