### PR TITLE
Fix for #254

### DIFF
--- a/doc/mansrc/rvs.md
+++ b/doc/mansrc/rvs.md
@@ -88,3 +88,6 @@ Runs rvs with the default test configuration file <i>[install_base]/conf/rvs.con
 <b>rvs -c conf/gpup1.conf -d 3 -j -l mylog.txt</b> \n
 Runs rvs with configuration file <i>conf/gpup1.conf</i> and writes output \n
 into log file <i>mylog.txt</i> using logging level 3 (INFO) in JSON format
+
+For more details consult the User Guide located in:
+<i>[install_base]/userguide/html/index.html</i>

--- a/doc/ugsrc/ug1main.md
+++ b/doc/ugsrc/ug1main.md
@@ -1841,6 +1841,36 @@ average of the bandwidth will be calculated and logged. The default value is
 1000 (1 second). It must be smaller than the duration key.</td></tr>
 </table>
 
+Please note that suitable values for **log\_interval** and **duration** depend
+on your system.
+
+- **log_interval**, in sequential mode, should be long enough to allow all
+transfer tests to finish at lest once. Number of transfers depends on number of
+peer NUMA nodes in your system. In parallel mode, it should be roughly 1.5 times
+the duration of single longest individual test.
+
+- **duration**, regardless of mode should be at least, 4 * log_interval.
+
+You may obtain indication of how long single transfer between two NUMA nodes
+take by running test with "-d 4" switch and observing DEBUG messages for
+transfer start/finish. An output may look like this:
+
+    [DEBUG ] [183940.634118] [action_1] pqt transfer 6 5 start
+    [DEBUG ] [183941.311671] [action_1] pqt transfer 6 5 finish
+    [DEBUG ] [183941.312746] [action_1] pqt transfer 4 5 start
+    [DEBUG ] [183941.990174] [action_1] pqt transfer 4 5 finish
+    [DEBUG ] [183941.991244] [action_1] pqt transfer 4 6 start
+    [DEBUG ] [183942.668687] [action_1] pqt transfer 4 6 finish
+    [DEBUG ] [183942.669756] [action_1] pqt transfer 5 4 start
+    [DEBUG ] [183943.340957] [action_1] pqt transfer 5 4 finish
+    [DEBUG ] [183943.342037] [action_1] pqt transfer 5 6 start
+    [DEBUG ] [183944.17957 ] [action_1] pqt transfer 5 6 finish
+    [DEBUG ] [183944.19032 ] [action_1] pqt transfer 6 4 start
+    [DEBUG ] [183944.700868] [action_1] pqt transfer 6 4 finish
+
+From this printout, it can be concluded that single transfer takes on average
+800ms. Values for **log\_interval** and **duration** should be set accordingly.
+
 @subsection usg102 10.2 Output
 
 Module specific output keys are described in the table below:
@@ -1880,6 +1910,15 @@ At the end of the test the average bytes/second will be calculated over the
 entire test duration, and will be logged as a result:
 
     [RESULT][<timestamp>][<action name>] p2p-bandwidth <gpu id> <peer gpu id> bidirectional: <bidirectional> <bandwidth > <duration>
+
+In some cases, based on particular value of **log\_interval** settings, you
+might get an output containing **nan GBps**:
+
+    [INFO  ] [186147.611737] [action_1] p2p-bandwidth  3254 50599  bidirectional: true  -nan GBps
+
+This means that the moving average calculation kicked in before at least one
+test transfer happened for those particular nodes in this moving average cycle.
+You should probably increase value of **log\_interval** in that case.
 
 @subsection usg103 10.3 Examples
 
@@ -2038,6 +2077,39 @@ interval over which the moving average of the bandwidth will be calculated and
 logged.</td></tr>
 </table>
 
+Please note that suitable values for **log\_interval** and **duration** depend
+on your system.
+
+- **log_interval**, in sequential mode, should be long enough to allow all
+transfer tests to finish at lest once. Number of transfers depends on number of
+peer NUMA nodes in your system. In parallel mode, it should be roughly 1.5 times
+the duration of single longest individual test.
+
+- **duration**, regardless of mode should be at least, 4 * log_interval.
+
+You may obtain indication of how long single transfer between two NUMA nodes
+take by running test with "-d 4" switch and observing DEBUG messages for
+transfer start/finish. An output may look like this:
+
+    [DEBUG ] [187024.729433] [action_1] pebb transfer 0 6 start
+    [DEBUG ] [187029.327818] [action_1] pebb transfer 0 6 finish
+    [DEBUG ] [187024.299150] [action_1] pebb transfer 1 6 start
+    [DEBUG ] [187029.473378] [action_1] pebb transfer 1 6 finish
+    [DEBUG ] [187023.227009] [action_1] pebb transfer 1 5 start
+    [DEBUG ] [187029.530203] [action_1] pebb transfer 1 5 finish
+    [DEBUG ] [187025.737675] [action_1] pebb transfer 3 5 start
+    [DEBUG ] [187030.134100] [action_1] pebb transfer 3 5 finish
+    [DEBUG ] [187027.19961 ] [action_1] pebb transfer 2 6 start
+    [DEBUG ] [187030.421181] [action_1] pebb transfer 2 6 finish
+    [DEBUG ] [187027.41475 ] [action_1] pebb transfer 2 5 start
+    [DEBUG ] [187031.293998] [action_1] pebb transfer 2 5 finish
+    [DEBUG ] [187027.71717 ] [action_1] pebb transfer 0 5 start
+    [DEBUG ] [187031.605326] [action_1] pebb transfer 0 5 finish
+
+From this printout, it can be concluded that single transfer takes on average
+5500ms. Values for **log\_interval** and **duration** should be set accordingly.
+
+
 @subsection usg112 11.2 Output
 
 Module specific output keys are described in the table below:
@@ -2060,12 +2132,22 @@ average of the bandwidth of the transfer will be calculated and logged. This
 interval is provided by the log_interval parameter and will have the following
 output format:
 
-    [INFO ][<timestamp>][<action name>] pcie-bandwidth <gpu id> h2d: <host_to_device> d2h: <device_to_host> <interval_bandwidth >
+    [INFO ][<timestamp>][<action name>] pcie-bandwidth <cpu node> <gpu id> h2d: <host_to_device> d2h: <device_to_host> <interval_bandwidth >
 
 At the end of the test the average bytes/second will be calculated over the
 entire test duration, and will be logged as a result:
 
     [RESULT][<timestamp>][<action name>] pcie-bandwidth <cpu node> <gpu id> h2d: <host_to_device> d2h: <device_to_host> < bandwidth > <duration>
+
+In some cases, based on particular value of **log\_interval** settings, you
+might get an output containing **nan GBps**:
+
+    [INFO  ] [187036.322945] [action_1] pcie-bandwidth  0 3254  h2d: true  d2h: true  -nanGBps
+
+This means that the moving average calculation kicked in before at least one
+test transfer happened for those particular nodes in this moving average cycle.
+You should probably increase value of **log\_interval** in that case.
+
 
 
 @subsection usg113 11.3 Examples

--- a/include/rvsloglp.h
+++ b/include/rvsloglp.h
@@ -30,6 +30,9 @@
 #include "rvsliblog.h"
 
 #define RVSDEBUG_ rvs::lp::Log(std::string(__FILE__)+"   "+__func__+":"\
++std::to_string(__LINE__), rvs::logdebug);
+
+#define RVSTRACE_ rvs::lp::Log(std::string(__FILE__)+"   "+__func__+":"\
 +std::to_string(__LINE__), rvs::logtrace);
 
 namespace rvs {

--- a/pebb.so/src/worker.cpp
+++ b/pebb.so/src/worker.cpp
@@ -60,14 +60,27 @@ pebbworker::~pebbworker() {}
  *
  * */
 void pebbworker::run() {
+  std::string msg;
+
+  msg = "[" + action_name + "] pebb thread " + std::to_string(src_node) + " "
+  + std::to_string(dst_node) + " has started";
+  rvs::lp::Log(msg, rvs::logdebug);
+
+  brun = true;
+
   while (brun) {
     do_transfer();
-    if (rvs::lp::Stopping()) {
-      break;
-    }
     std::this_thread::yield();
+
+    if (rvs::lp::Stopping()) {
+      brun = false;
+      RVSTRACE_
+    }
   }
-  log("pebb worker thread has finished", rvs::logdebug);
+
+  msg = "[" + action_name + "] pebb thread " + std::to_string(src_node) + " "
+  + std::to_string(dst_node) + " has finished";
+  rvs::lp::Log(msg, rvs::logdebug);
 }
 
 /**
@@ -78,7 +91,11 @@ void pebbworker::run() {
  *
  * */
 void pebbworker::stop() {
-  log("pebb in pebbworker::stop()", rvs::logdebug);
+  std::string msg;
+
+  msg = "[" + stop_action_name + "] pebb transfer " + std::to_string(src_node)
+      + " "       + std::to_string(dst_node) + " in pebbworker::stop()";
+  rvs::lp::Log(msg, rvs::logtrace);
 
   brun = false;
 
@@ -132,6 +149,16 @@ int pebbworker::initialize(int Src, int Dst, bool h2d, bool d2h) {
 int pebbworker::do_transfer() {
   double duration;
   int sts;
+  unsigned int startsec;
+  unsigned int startusec;
+  unsigned int endsec;
+  unsigned int endusec;
+  std::string msg;
+
+  msg = "[" + action_name + "] pebb transfer " + std::to_string(src_node) + " "
+      + std::to_string(dst_node) + " ";
+
+  rvs::lp::get_ticks(&startsec, &startusec);
 
   for (size_t i = 0; i < pHsa->size_list.size(); i++) {
     current_size = pHsa->size_list[i];
@@ -160,6 +187,11 @@ int pebbworker::do_transfer() {
       running_duration += duration;
     }
   }
+
+  rvs::lp::get_ticks(&endsec, &endusec);
+  rvs::lp::Log(msg + "start", rvs::logdebug, startsec, startusec);
+  rvs::lp::Log(msg + "finish", rvs::logdebug, endsec, endusec);
+
   return 0;
 }
 

--- a/rvs/conf/pebb_test3.conf
+++ b/rvs/conf/pebb_test3.conf
@@ -15,8 +15,8 @@ actions:
 - name: action_1 
   device: all
   module: pebb
-  log_interval: 1000
-  duration: 10000
+  log_interval: 7000
+  duration: 30000
   device_to_host: true
   host_to_device: true
   parallel: false

--- a/rvs/conf/pebb_test4.conf
+++ b/rvs/conf/pebb_test4.conf
@@ -14,9 +14,10 @@
 
 actions:
 - name: action_1 
-  device: 50599 3254
-  deviceid: 26720
+  device: all
   module: pebb
-  log_interval: 1000
-  duration: 8000
+  log_interval: 6000
+  duration: 19000
+  device_to_host: true
+  host_to_device: true
   parallel: true

--- a/rvs/conf/pqt12.conf
+++ b/rvs/conf/pqt12.conf
@@ -1,0 +1,10 @@
+actions:
+- name: action_1 
+  device: all
+  module: pqt
+  log_interval: 5000
+  duration: 18000
+  peers: all
+  test_bandwidth: true
+  bidirectional: true
+

--- a/rvs/conf/pqt13.conf
+++ b/rvs/conf/pqt13.conf
@@ -1,0 +1,11 @@
+actions:
+- name: action_1 
+  device: all
+  module: pqt
+  log_interval: 1000
+  duration: 5000
+  peers: all
+  test_bandwidth: true
+  bidirectional: true
+  parallel: true
+

--- a/src/rvshsa.cpp
+++ b/src/rvshsa.cpp
@@ -245,42 +245,44 @@ void rvs::hsa::InitAgents() {
   string log_msg;
 
   // Initialize Roc Runtime
-  rvs::lp::Log("[PQT] Before hsa_init ...", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] Before hsa_init ...", rvs::logtrace);
   status = hsa_init();
-  rvs::lp::Log("[PQT] After hsa_init ...", rvs::logdebug);
-  print_hsa_status("[PQT] InitAgents - hsa_init()", status);
+  rvs::lp::Log("[RVSHSA] After hsa_init ...", rvs::logtrace);
+  print_hsa_status("[RVSHSA] InitAgents - hsa_init()", status);
 
   // Initialize profiling
-  rvs::lp::Log("[PQT] Before hsa_amd_profiling_async_copy_enable ...",
-               rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] Before hsa_amd_profiling_async_copy_enable ...",
+               rvs::logtrace);
   status = hsa_amd_profiling_async_copy_enable(true);
-  rvs::lp::Log("[PQT] Before hsa_amd_profiling_async_copy_enable ...",
-               rvs::logdebug);
-  print_hsa_status("[PQT] InitAgents - hsa_amd_profiling_async_copy_enable()",
+  rvs::lp::Log("[RVSHSA] Before hsa_amd_profiling_async_copy_enable ...",
+               rvs::logtrace);
+  print_hsa_status(
+    "[RVSHSA] InitAgents - hsa_amd_profiling_async_copy_enable()",
                    status);
 
   // Populate the lists of agents
-  rvs::lp::Log("[PQT] Before hsa_iterate_agents ...", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] Before hsa_iterate_agents ...", rvs::logtrace);
   status = hsa_iterate_agents(ProcessAgent, &agent_list);
-  rvs::lp::Log("[PQT] After hsa_iterate_agents ...", rvs::logdebug);
-  print_hsa_status("[PQT] InitAgents - hsa_iterate_agents()", status);
+  rvs::lp::Log("[RVSHSA] After hsa_iterate_agents ...", rvs::logtrace);
+  print_hsa_status("[RVSHSA] InitAgents - hsa_iterate_agents()", status);
 
   for (uint32_t i = 0; i < agent_list.size(); i++) {
-    rvs::lp::Log("[PQT] ============================", rvs::logdebug);
-    log_msg = "[PQT] InitAgents - agent with name = "  +
+    rvs::lp::Log("[RVSHSA] ============================", rvs::logtrace);
+    log_msg = "[RVSHSA] InitAgents - agent with name = "  +
       agent_list[i].agent_name + " and device_type = " +
       agent_list[i].agent_device_type;
-    rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
-    rvs::lp::Log("[PQT] ============================", rvs::logdebug);
+    rvs::lp::Log(log_msg.c_str(), rvs::logtrace);
+    rvs::lp::Log("[RVSHSA] ============================", rvs::logtrace);
 
     // Populate the list of memory pools
-    rvs::lp::Log("[PQT] Before hsa_amd_agent_iterate_memory_pools ...",
-                 rvs::logdebug);
+    rvs::lp::Log("[RVSHSA] Before hsa_amd_agent_iterate_memory_pools ...",
+                 rvs::logtrace);
     status = hsa_amd_agent_iterate_memory_pools(agent_list[i].agent,
                                                 ProcessMemPool, &agent_list[i]);
-    rvs::lp::Log("[PQT] After hsa_amd_agent_iterate_memory_pools ...",
-                 rvs::logdebug);
-    print_hsa_status("[PQT] InitAgents - hsa_amd_agent_iterate_memory_pools()",
+    rvs::lp::Log("[RVSHSA] After hsa_amd_agent_iterate_memory_pools ...",
+                 rvs::logtrace);
+    print_hsa_status(
+      "[RVSHSA] InitAgents - hsa_amd_agent_iterate_memory_pools()",
                      status);
 
     // separate the lists
@@ -329,24 +331,24 @@ hsa_status_t rvs::hsa::ProcessAgent(hsa_agent_t agent, void* data) {
   vector<AgentInformation>* agent_l =
   reinterpret_cast<vector<AgentInformation>*>(data);
 
-  rvs::lp::Log("[PQT] Called ProcessAgent() ...", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] Called ProcessAgent() ...", rvs::logtrace);
 
   // Get the name of the agent
   status = hsa_agent_get_info(agent, HSA_AGENT_INFO_NAME, agent_name);
-  print_hsa_status("[PQT] HSA_AGENT_INFO_NAME", status);
-  rvs::lp::Log(string("pqt agent_name: ") + agent_name, rvs::logdebug);
+  print_hsa_status("[RVSHSA] HSA_AGENT_INFO_NAME", status);
+  rvs::lp::Log(string("pqt agent_name: ") + agent_name, rvs::logtrace);
 
   // Get device type
   status = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &device_type);
-  print_hsa_status("[PQT] HSA_AGENT_INFO_DEVICE", status);
+  print_hsa_status("[RVSHSA] HSA_AGENT_INFO_DEVICE", status);
 
   status = hsa_agent_get_info(agent, HSA_AGENT_INFO_NODE, &node);
-  print_hsa_status("[PQT] HSA_AGENT_INFO_NODE", status);
+  print_hsa_status("[RVSHSA] HSA_AGENT_INFO_NODE", status);
   agent_info.node = node;
-  rvs::lp::Log("pqt node: " + std::to_string(node), rvs::logdebug);
+  rvs::lp::Log("pqt node: " + std::to_string(node), rvs::logtrace);
 
   log_agent_name = agent_name;
-  log_msg = "[PQT] Found agent with name = "  + log_agent_name +
+  log_msg = "[RVSHSA] Found agent with name = "  + log_agent_name +
     " and device_type = ";
   switch (device_type) {
     case HSA_DEVICE_TYPE_CPU : {
@@ -365,7 +367,7 @@ hsa_status_t rvs::hsa::ProcessAgent(hsa_agent_t agent, void* data) {
       break;
     };
   }
-  rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
+  rvs::lp::Log(log_msg.c_str(), rvs::logtrace);
   // add agent to list
   agent_info.agent = agent;
   agent_info.agent_name = log_agent_name;
@@ -395,7 +397,7 @@ hsa_status_t rvs::hsa::ProcessMemPool(hsa_amd_memory_pool_t pool, void* data) {
   status = hsa_amd_memory_pool_get_info(pool,
                                         HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
                                         &segment);
-  RVSDEBUG_
+  RVSTRACE_
   print_hsa_status(__FILE__, __LINE__, __func__, status);
   if (HSA_AMD_SEGMENT_GLOBAL != segment) {
     return HSA_STATUS_SUCCESS;
@@ -444,15 +446,17 @@ hsa_status_t rvs::hsa::ProcessMemPool(hsa_amd_memory_pool_t pool, void* data) {
   bool is_kernarg = (HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT & flag);
 
   // Update the pool handle for system memory if kernarg is true
-  rvs::lp::Log("[PQT] ****************************************", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] ****************************************",
+               rvs::logtrace);
   if (is_kernarg) {
     agent_info->sys_pool = pool;
-    rvs::lp::Log("[PQT] Found system memory region", rvs::logdebug);
+    rvs::lp::Log("[RVSHSA] Found system memory region", rvs::logtrace);
   } else if (owner_access != HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
     agent_info->mem_pool_list.push_back(pool);
-    rvs::lp::Log("[PQT] Found regular memory region", rvs::logdebug);
+    rvs::lp::Log("[RVSHSA] Found regular memory region", rvs::logtrace);
   }
-  rvs::lp::Log("[PQT] ****************************************", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] ****************************************",
+               rvs::logtrace);
 
   return HSA_STATUS_SUCCESS;
 }
@@ -490,21 +494,21 @@ double rvs::hsa::GetCopyTime(bool bidirectional,
   hsa_amd_profiling_async_copy_time_t async_time_fwd {0, 0};
   status = hsa_amd_profiling_get_async_copy_time(signal_fwd, &async_time_fwd);
   print_hsa_status(
-    "[PQT] GetCopyTime - hsa_amd_profiling_get_async_copy_time(forward)",
+    "[RVSHSA] GetCopyTime - hsa_amd_profiling_get_async_copy_time(forward)",
                    status);
   if (bidirectional == false) {
-    RVSDEBUG_
+    RVSTRACE_
     return(async_time_fwd.end - async_time_fwd.start);
   }
 
   hsa_amd_profiling_async_copy_time_t async_time_rev {0, 0};
   status = hsa_amd_profiling_get_async_copy_time(signal_rev, &async_time_rev);
   print_hsa_status(
-    "[PQT] GetCopyTime - hsa_amd_profiling_get_async_copy_time(backward)",
+    "[RVSHSA] GetCopyTime - hsa_amd_profiling_get_async_copy_time(backward)",
                    status);
   double start = std::min(async_time_fwd.start, async_time_rev.start);
   double end = std::max(async_time_fwd.end, async_time_rev.end);
-  RVSDEBUG_
+  RVSTRACE_
   return(end - start);
 }
 
@@ -605,11 +609,11 @@ int rvs::hsa::Allocate(int SrcAgent, int DstAgent, size_t Size,
     // suitable destination buffer not foud, deallocate src buff and exit
     hsa_amd_memory_pool_free(srcbuff);
 
-    RVSDEBUG_
+    RVSTRACE_
     return -1;
   }
 
-  RVSDEBUG_
+  RVSTRACE_
   return -1;
 }
 
@@ -646,13 +650,13 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
   void* dst_ptr_rev = nullptr;
   hsa_signal_t signal_rev;
 
-  RVSDEBUG_
+  RVSTRACE_
 
   // given NUMA nodes, find agent indexes
   src_ix_fwd = FindAgent(SrcNode);
   dst_ix_fwd = FindAgent(DstNode);
   if (src_ix_fwd < 0 || dst_ix_fwd < 0) {
-    RVSDEBUG_
+    RVSTRACE_
     return -1;
   }
 
@@ -661,7 +665,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
            &src_pool_fwd, &src_ptr_fwd,
            &dst_pool_fwd, &dst_ptr_fwd);
   if (sts) {
-    RVSDEBUG_
+    RVSTRACE_
     return -1;
   }
 
@@ -670,7 +674,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
   if (status != HSA_STATUS_SUCCESS) {
       hsa_amd_memory_pool_free(src_ptr_fwd);
       hsa_amd_memory_pool_free(dst_ptr_fwd);
-      RVSDEBUG_
+      RVSTRACE_
       return -1;
   }
 
@@ -686,7 +690,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
     if (sts) {
       hsa_amd_memory_pool_free(src_ptr_fwd);
       hsa_amd_memory_pool_free(dst_ptr_fwd);
-      RVSDEBUG_
+      RVSTRACE_
       return -1;
     }
 
@@ -698,7 +702,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
       hsa_amd_memory_pool_free(src_ptr_rev);
       hsa_amd_memory_pool_free(dst_ptr_rev);
       hsa_signal_destroy(signal_fwd);
-      RVSDEBUG_
+      RVSTRACE_
       return -1;
     }
   }
@@ -710,7 +714,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
                                      Size,
                                      0, NULL, signal_fwd);
   if (bidirectional) {
-    RVSDEBUG_
+    RVSTRACE_
     // initiate reverse transfer
     hsa_signal_store_relaxed(signal_rev, 1);
     status = hsa_amd_memory_async_copy(
@@ -727,7 +731,7 @@ int rvs::hsa::SendTraffic(uint32_t SrcNode, uint32_t DstNode,
   if (bidirectional == true) {
     while (hsa_signal_wait_acquire(signal_rev, HSA_SIGNAL_CONDITION_LT,
     1, uint64_t(-1), HSA_WAIT_STATE_ACTIVE)) {}
-    RVSDEBUG_
+    RVSTRACE_
   }
 
   // get transfer duration
@@ -824,9 +828,9 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   double curr_time;
   double bandwidth;
 
-  rvs::lp::Log("[PQT] ++++++++++++++++++++++++++++++++++++++", rvs::logdebug);
-  rvs::lp::Log("[PQT] send_traffic called ... ", rvs::logdebug);
-  rvs::lp::Log("[PQT] ++++++++++++++++++++++++++++++++++++++", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] ++++++++++++++++++++++++++++++++++++++", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] send_traffic called ... ", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] ++++++++++++++++++++++++++++++++++++++", rvs::logdebug);
 
   snprintf(s_buff, sizeof(s_buff), "%lX", src_agent.handle);
   rvs::lp::Log(std::string("src_agent = ") + s_buff, rvs::logdebug);
@@ -835,23 +839,23 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   rvs::lp::Log(std::string("dst_agent = ") + s_buff, rvs::logdebug);
 
   // print current size
-  rvs::lp::Log("[PQT] ---------------------------------------", rvs::logdebug);
-  log_msg = "[PQT] send_traffic - curr_size = " +
+  rvs::lp::Log("[RVSHSA] ---------------------------------------", rvs::logdebug);
+  log_msg = "[RVSHSA] send_traffic - curr_size = " +
     std::to_string(curr_size) + " Bytes";
   rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
-  rvs::lp::Log("[PQT] ---------------------------------------", rvs::logdebug);
+  rvs::lp::Log("[RVSHSA] ---------------------------------------", rvs::logdebug);
 
   // Allocate buffers in src and dst pools
   status = hsa_amd_memory_pool_allocate(src_buff, curr_size, 0,
                                     static_cast<void**>(&src_pool_pointer_fwd));
-  print_hsa_status("[PQT] send_traffic - hsa_amd_memory_pool_allocate(SRC)",
+  print_hsa_status("[RVSHSA] send_traffic - hsa_amd_memory_pool_allocate(SRC)",
                    status);
   snprintf(s_buff, sizeof(s_buff), "%p", src_pool_pointer_fwd);
   rvs::lp::Log(std::string("src_pool_pointer_fwd = ") + s_buff, rvs::logdebug);
 
   status = hsa_amd_memory_pool_allocate(dst_buff, curr_size, 0,
                                   static_cast<void**>(&dst_pool_pointer_fwd));
-  print_hsa_status("[PQT] send_traffic - hsa_amd_memory_pool_allocate(DST)",
+  print_hsa_status("[RVSHSA] send_traffic - hsa_amd_memory_pool_allocate(DST)",
                    status);
   snprintf(s_buff, sizeof(s_buff), "%p", dst_pool_pointer_fwd);
   rvs::lp::Log(std::string("dst_pool_pointer_fwd = ") + s_buff, rvs::logdebug);
@@ -860,7 +864,7 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
     status = hsa_amd_memory_pool_allocate(src_buff, curr_size, 0,
                                   static_cast<void**>(&src_pool_pointer_rev));
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_amd_memory_pool_allocate(SRC)",
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_amd_memory_pool_allocate(SRC)",
                      status);
     snprintf(s_buff, sizeof(s_buff), "%p", src_pool_pointer_rev);
     rvs::lp::Log(std::string("src_pool_pointer_rev = ") + s_buff,
@@ -869,7 +873,7 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
     status = hsa_amd_memory_pool_allocate(dst_buff, curr_size, 0,
                                   static_cast<void**>(&dst_pool_pointer_rev));
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_amd_memory_pool_allocate(DST)",
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_amd_memory_pool_allocate(DST)",
                      status);
     snprintf(s_buff, sizeof(s_buff), "%p", dst_pool_pointer_rev);
     rvs::lp::Log(std::string("dst_pool_pointer_rev = ") + s_buff,
@@ -878,18 +882,18 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
 
   // Create a signal to wait on copy operation
   status = hsa_signal_create(1, 0, NULL, &signal_fwd);
-  print_hsa_status("[PQT] send_traffic - hsa_signal_create()", status);
+  print_hsa_status("[RVSHSA] send_traffic - hsa_signal_create()", status);
 
   // get agent access
   status = hsa_amd_agents_allow_access(1, &src_agent,
                                        NULL, dst_pool_pointer_fwd);
   print_hsa_status(
-    "[PQT] send_traffic - hsa_amd_agents_allow_access(SRC)", status);
+    "[RVSHSA] send_traffic - hsa_amd_agents_allow_access(SRC)", status);
 
   status = hsa_amd_agents_allow_access(1, &dst_agent,
                                        NULL, src_pool_pointer_fwd);
   print_hsa_status(
-    "[PQT] send_traffic - hsa_amd_agents_allow_access(DST)", status);
+    "[RVSHSA] send_traffic - hsa_amd_agents_allow_access(DST)", status);
 
   // store signal
   hsa_signal_store_relaxed(signal_fwd, 1);
@@ -897,18 +901,18 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   if (bidirectional == true) {
     status = hsa_signal_create(1, 0, NULL, &signal_rev);
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_signal_create()", status);
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_signal_create()", status);
 
     status = hsa_amd_agents_allow_access(1, &src_agent,
                                          NULL, dst_pool_pointer_rev);
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_amd_agents_allow_access(SRC)",
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_amd_agents_allow_access(SRC)",
                      status);
 
     status = hsa_amd_agents_allow_access(1, &dst_agent,
                                          NULL, src_pool_pointer_rev);
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_amd_agents_allow_access(DST)",
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_amd_agents_allow_access(DST)",
                      status);
 
     hsa_signal_store_relaxed(signal_rev, 1);
@@ -919,11 +923,11 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   status = hsa_amd_agent_memory_pool_get_info(src_agent, dst_buff,
         HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access);
   print_hsa_status(
-    "[PQT] send_traffic - hsa_amd_agent_memory_pool_get_info(SRC->DST)",
+    "[RVSHSA] send_traffic - hsa_amd_agent_memory_pool_get_info(SRC->DST)",
                    status);
 
   if (access == HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
-    log_msg = std::string("[PQT] send_traffic - HSA_AMD_MEMORY_POOL_ACCESS_") +
+    log_msg = std::string("[RVSHSA] send_traffic - HSA_AMD_MEMORY_POOL_ACCESS_") +
     "NEVER_ALLOWED for SRC -> DST), so skip it ...";
     rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
     return 0;
@@ -932,11 +936,11 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   if (bidirectional == true) {
     status = hsa_amd_agent_memory_pool_get_info(dst_agent, src_buff,
                                 HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access);
-    print_hsa_status(std::string("[PQT] send_traffic BIDIRECTIONAL - ") +
+    print_hsa_status(std::string("[RVSHSA] send_traffic BIDIRECTIONAL - ") +
     "hsa_amd_agent_memory_pool_get_info(DST->SRC)", status);
 
     if (access == HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
-      log_msg = std::string("[PQT] send_traffic BIDIRECTIONAL - HSA_AMD_") +
+      log_msg = std::string("[RVSHSA] send_traffic BIDIRECTIONAL - HSA_AMD_") +
       "MEMORY_POOL_ACCESS_NEVER_ALLOWED for DST -> SRC), so skip it ...";
       rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
       return 0;
@@ -951,41 +955,41 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
                                      src_pool_pointer_fwd, src_agent, curr_size,
                                      0, NULL, signal_fwd);
   print_hsa_status(
-    "[PQT] send_traffic - hsa_amd_memory_async_copy(SRC -> DST)", status);
+    "[RVSHSA] send_traffic - hsa_amd_memory_async_copy(SRC -> DST)", status);
 
   if (bidirectional == true) {
     status = hsa_amd_memory_async_copy(src_pool_pointer_rev, src_agent,
                                        dst_pool_pointer_rev, dst_agent,
                                        curr_size, 0, NULL, signal_rev);
     print_hsa_status(
-      "[PQT] send_traffic BIDIRECTIONAL - hsa_amd_memory_async_copy(DST -> SRC)"
+      "[RVSHSA] send_traffic BIDIRECTIONAL - hsa_amd_memory_async_copy(DST -> SRC)"
       , status);
   }
 
   // Wait for the forward copy operation to complete
-  log_msg = std::string("[PQT] send_traffic - ") +
+  log_msg = std::string("[RVSHSA] send_traffic - ") +
       "hsa_signal_wait_acquire(SRC -> DST) before ...";
   rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
   while (hsa_signal_wait_acquire(signal_fwd, HSA_SIGNAL_CONDITION_LT,
     1, uint64_t(-1), HSA_WAIT_STATE_ACTIVE)) {}
   log_msg =
-    "[PQT] send_traffic - hsa_signal_wait_acquire(SRC -> DST) after ...";
+    "[RVSHSA] send_traffic - hsa_signal_wait_acquire(SRC -> DST) after ...";
   rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
 
   if (bidirectional == true) {
-    log_msg = std::string("[PQT] send_traffic BIDIRECTIONAL - ") +
+    log_msg = std::string("[RVSHSA] send_traffic BIDIRECTIONAL - ") +
     "hsa_signal_wait_acquire(DST -> SRC) before ...";
     rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
     while (hsa_signal_wait_acquire(signal_rev, HSA_SIGNAL_CONDITION_LT,
       1, uint64_t(-1), HSA_WAIT_STATE_ACTIVE)) {}
     log_msg =
-      std::string("[PQT] send_traffic BIDIRECTIONAL - ") +
+      std::string("[RVSHSA] send_traffic BIDIRECTIONAL - ") +
       "hsa_signal_wait_acquire(DST -> SRC) after ...";
     rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
   }
 
   curr_time = GetCopyTime(bidirectional, signal_fwd, signal_rev)/1000000000;
-  log_msg = "[PQT] send_traffic - curr_time = " + std::to_string(curr_time);
+  log_msg = "[RVSHSA] send_traffic - curr_time = " + std::to_string(curr_time);
   rvs::lp::Log(log_msg.c_str(), rvs::logdebug);
 
   // convert to GB/s
@@ -994,7 +998,7 @@ double rvs::hsa::send_traffic(hsa_agent_t src_agent, hsa_agent_t dst_agent,
   }
   bandwidth = (curr_size / curr_time);
   bandwidth /= (1024*1024*1024);
-  log_msg = "[PQT] send_traffic - curr_size = " + std::to_string(curr_size) +
+  log_msg = "[RVSHSA] send_traffic - curr_size = " + std::to_string(curr_size) +
     " Bytes and curr_time = " + std::to_string(curr_time) + " bandwidth = " +
     std::to_string(bandwidth) + " GBytes/s";
   rvs::lp::Log(log_msg.c_str(), rvs::logdebug);


### PR DESCRIPTION
**nanGBps** is displayed when moving average kicks in before at least one test transfer is performed for particular two nodes. 

This is not an error and basically indicates that the test needs to be run with longer `log_interval` and/or `duration` This is particularly true if the test is run on a system with number of CPUs/GPUs.

I still put in couple of changes in order to facilitate finding duration of a single test, fixed some bugs and have updated PQT and PEBB in User Guide to explain this situation accordingly.

To test run:
./rvs -c conf/pqt12.conf -d 3
./rvs -c conf/pqt13.conf -d 3
./rvs -c conf/pebb_test3.conf -d 3
./rvs -c conf/pebb_test4.conf -d 3
