### PR TITLE
Iss280

### DIFF
--- a/include/rvsliblog.h
+++ b/include/rvsliblog.h
@@ -45,6 +45,8 @@ typedef void  (*t_cbAddInt)(void* Parent, const char* Key, const int Val);
 typedef void  (*t_cbAddNode)(void* Parent, void* Child);
 typedef void  (*t_cbStop)(uint16_t flags);
 typedef bool  (*t_cbStopping)(void);
+typedef int   (*t_rvs_module_err)(const char*, const char*, const char*);
+
 
 /**
  * @brief Module initialization structure
@@ -70,6 +72,8 @@ typedef struct tag_module_init {
   t_cbStop             cbStop;
   //! pointer to rvs::logger::Stopping() function
   t_cbStopping         cbStopping;
+  //! pointer to rvs::logger::Err() function
+  t_rvs_module_err     cbErr;
 } T_MODULE_INIT;
 
 #ifdef __cplusplus

--- a/include/rvsliblogger.h
+++ b/include/rvsliblogger.h
@@ -72,6 +72,7 @@ class logger {
   static  int    JsonPatchAppend(void);
   static  void   Stop(uint16_t flags);
   static  bool   Stopping(void);
+  static  int    Err(const char *Module, const char *Action, const char *Message);
 
  protected:
   //! Current logging level (0..5)

--- a/include/rvsloglp.h
+++ b/include/rvsloglp.h
@@ -71,6 +71,9 @@ class lp {
   static bool  get_ticks(unsigned int* psec, unsigned int* pusec);
   static void  Stop(uint16_t flags);
   static bool  Stopping();
+  static int   Err(const std::string &Msg);
+  static int   Err(const std::string &Module, const std::string &Msg);
+  static int   Err(const std::string &Module, const std::string &Action, const std::string &Msg);
 
  protected:
   //! Module init structure passed through Initialize() method

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -225,6 +225,7 @@ int rvs::module::initialize() {
   d.cbAddNode         = rvs::logger::AddNode;
   d.cbStop            = rvs::logger::Stop;
   d.cbStopping        = rvs::logger::Stopping;
+  d.cbErr             = rvs::logger::Err;
 
   return (*rvs_module_init)(reinterpret_cast<void*>(&d));
 }

--- a/src/rvsliblogger.cpp
+++ b/src/rvsliblogger.cpp
@@ -549,3 +549,39 @@ bool rvs::logger::Stopping(void) {
   // return stop flag
   return bStop;
 }
+
+
+/**
+ * @brief Output Error message
+ * 
+ * @param Module module where error happened
+ * @param Action action where error happened
+ * @param Message Message to log
+ * @return 0 - success, non-zero otherwise
+ *
+ */
+int rvs::logger::Err(const char* Module, const char* Action
+        , const char* Message) {
+
+  std::string module =
+      Module != nullptr ? std::string("[") + Module + "] " : ""; 
+  std::string action =
+      Action != nullptr ? std::string("[") + Action + "] " : "";
+  std::string message = Message;
+  std::string out;
+  out = "RVS-ERROR ";
+  out += module + action + message;
+  std::cerr << out << std::endl;
+  return 0;
+}
+
+/**
+ * @brief Output log message
+ *
+ * @param Message Message to log
+ * @param LogLevel Logging level
+ * @param Sec secconds from system start
+ * @param uSec microseconds in current second
+ * @return 0 - success, non-zero otherwise
+ *
+ */

--- a/src/rvsloglp.cpp
+++ b/src/rvsloglp.cpp
@@ -50,6 +50,7 @@ int   rvs::lp::Initialize(const T_MODULE_INIT* pMi) {
   mi.cbAddNode         = pMi->cbAddNode;
   mi.cbStop            = pMi->cbStop;
   mi.cbStopping        = pMi->cbStopping;
+  mi.cbErr             = pMi->cbErr;
 
   return 0;
 }
@@ -272,4 +273,40 @@ void  rvs::lp::Stop(uint16_t flags) {
  */
 bool  rvs::lp::Stopping() {
   return (*mi.cbStopping)();
+}
+
+/**
+ * @brief Log Error output
+ *
+ * @param Message Message to log
+ * @return 0 - success, non-zero otherwise
+ *
+ */
+int rvs::lp::Err(const std::string &Message) {
+  return (*mi.cbErr)(nullptr, nullptr, Message.c_str());
+}
+
+/**
+ * @brief Log Error output
+ *
+ * @param Module  Module where error happend
+ * @param Message Message to log
+ * @return 0 - success, non-zero otherwise
+ *
+ */
+int rvs::lp::Err(const std::string &Module, const std::string &Message) {
+  return (*mi.cbErr)(Module.c_str(), nullptr, Message.c_str());
+}
+
+/**
+ * @brief Log Error output
+ *
+ * @param Module  Module where error happened
+ * @param Action  Action where error happened
+ * @param Message Message to log
+ * @return 0 - success, non-zero otherwise
+ *
+ */
+int rvs::lp::Err(const std::string &Module, const std::string &Action, const std::string &Message) {
+  return (*mi.cbErr)(Module.c_str(), Action.c_str(), Message.c_str());
 }


### PR DESCRIPTION
functions added for Error centralization:

1. static int Err(const std::string& Msg);
2. static int Err(const std::string& Module, const std::string& Msg);
3. static int Err(const std::string& Module, const std::string& Action, const std::string& Msg);