### PR TITLE
To show xGMI in p2p strType instead of unknown

### DIFF
--- a/src/rvshsa.cpp
+++ b/src/rvshsa.cpp
@@ -1055,6 +1055,9 @@ int rvs::hsa::GetLinkInfo(uint32_t SrcNode, uint32_t DstNode,
       case HSA_AMD_LINK_INFO_TYPE_INFINBAND:
         rvslinkinfo.strtype = "InfiniBand";
         break;
+      case HSA_AMD_LINK_INFO_TYPE_XGMI:
+        rvslinkinfo.strtype = "xGMI";
+        break;
       default:
         RVSHSATRACE_
         rvslinkinfo.strtype = "unknown-"


### PR DESCRIPTION
xGMI p2p detection doesn't work, it would show "unknown" to xGMI:
```
[RESULT] [  3450.761422] [action_4] p2p 8957 8957 peers:false distance:-1
[RESULT] [  3450.761477] [action_4] p2p 8957 42463 peers:true distance:15 unknown-4:15
[RESULT] [  3450.761586] [action_4] p2p 8957 36464 peers:true distance:15 unknown-4:15
[RESULT] [  3450.761637] [action_4] p2p 8957 53386 peers:true distance:30 unknown-4:30
[RESULT] [  3450.761682] [action_4] p2p 42463 8957 peers:true distance:15 unknown-4:15

```
According to /opt/rocm/hsa/include/hsa/hsa_ext_amd.h, the xGMI link type should be HSA_AMD_LINK_INFO_TYPE_XGMI = 4, I updated the rvs::hsa::GetLinkInfo in src/rvshsa.cpp to include a case for HSA_AMD_LINK_INFO_TYPE_XGMI.

```
[RESULT] [118063.710359] [action_4] p2p 8957 8957 peers:false distance:-1
[RESULT] [118063.710388] [action_4] p2p 8957 42463 peers:true distance:15 xGMI:15
[RESULT] [118063.710411] [action_4] p2p 8957 36464 peers:true distance:15 xGMI:15
[RESULT] [118063.710431] [action_4] p2p 8957 53386 peers:true distance:30 xGMI:30
[RESULT] [118063.710450] [action_4] p2p 42463 8957 peers:true distance:15 xGMI:15
```