### PR TITLE
Printing correct CPU Id in results in pebb report.

### DIFF
--- a/pebb.so/include/action.h
+++ b/pebb.so/include/action.h
@@ -61,6 +61,7 @@ class pebb_action : public rvs::actionbase {
   typedef struct bandwidth{
      string         finalBandwith;
      uint16_t       GPUId;
+     uint16_t       CPUId;
   }bandwidth;
 
   vector<bandwidth>   resultBandwidth;

--- a/pebb.so/src/action.cpp
+++ b/pebb.so/src/action.cpp
@@ -565,6 +565,7 @@ int pebb_action::print_final_average() {
 
     bw.finalBandwith = buff;
     bw.GPUId = dst_id;
+    bw.CPUId = src_node;
 
     resultBandwidth.push_back(bw);
 

--- a/pebb.so/src/action_run.cpp
+++ b/pebb.so/src/action_run.cpp
@@ -177,7 +177,7 @@ int pebb_action::run() {
 
   std::cout << " \n =========================================================================================================================";
   for(auto it = resultBandwidth.begin(); it != resultBandwidth.end(); it++) {
-     std::cout << " \n\n PCIE Bandwidth from , CPU::" << cnt << " to GPU Id::" << it[cnt].GPUId << " is " << it[cnt].finalBandwith << "\n\n";
+     std::cout << " \n\n PCIE Bandwidth from , CPU::" << it->CPUId<< " to GPU Id::" << it->GPUId << " is " << it->finalBandwith << "\n\n";
   }
   std::cout << " ========================================================================================================================= \n";
 


### PR DESCRIPTION
Instead of printing 0 as id for all CPUs choose
Correct value for CPU and GPU for bandwidth reporting