### PR TITLE
Adding man files to common location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,7 @@ add_custom_target(rvs_userguide ALL
 add_dependencies(rvs_userguide rvs_doc)
 
 install(FILES "${CMAKE_BINARY_DIR}/doc/man/man1/rvs.1"
-  DESTINATION ${CMAKE_PACKAGING_INSTALL_PREFIX}/rvs/man
+  DESTINATION ${CMAKE_PACKAGING_INSTALL_PREFIX}/share/man/man1
   COMPONENT applications
 )
 


### PR DESCRIPTION
RVS man files under rvs/ moved to /opt/rocm/share/man/man1
Since rocgdb and other man files are under above location
And asingle common manpath can be set up if all man files
are under common location:
Implementing as requested in: https://github.com/RadeonOpenCompute/ROCm/issues/1359 

Signed-off-by: Manoj S K <Manoj.SK@amd.com>