### PR TITLE
Logging to identify MCM GPUs.

### DIFF
--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -33,6 +33,8 @@
 #include <algorithm>
 #include <memory>
 #include <map>
+#include <iomanip>
+#include <sstream>
 
 #ifdef __cplusplus
 extern "C" {
@@ -600,6 +602,9 @@ int iet_action::get_all_selected_gpus(void) {
     bool amd_gpus_found = false;
     map<int, uint16_t> iet_gpus_device_index;
     std::string msg;
+    bool mcm_die = false;
+    bool amd_mcm_gpu_found = false;
+    std::stringstream msg_stream;
 
     hipGetDeviceCount(&hip_num_gpu_devices);
     if (hip_num_gpu_devices < 1)
@@ -651,7 +656,30 @@ int iet_action::get_all_selected_gpus(void) {
                 (std::pair<int, uint16_t>(i, gpu_id));
             amd_gpus_found = true;
         }
+
+        /* Check if GPU is die in MCM GPU */
+        mcm_die =  gpu_check_if_mcm_die(devId);
+	if (true == mcm_die) {
+
+		msg_stream.str("");
+                msg_stream << "GPU ID : " << std::setw(5) << gpu_id << " - " << "Device : " << std::setw(5) << devId <<
+			" - " << "GPU is a die/chiplet in Multi-Chip Module (MCM) GPU";
+		rvs::lp::Log(msg_stream.str(), rvs::logresults);
+
+		amd_mcm_gpu_found = true;
+	}
     }
+
+    /* AMD MCM GPU/s was found in the system */
+    if (true == amd_mcm_gpu_found) {
+
+	    msg_stream.str("");
+	    msg_stream << "Note: The system has Multi-Chip Module (MCM) GPU/s." << "\n" 
+		    << "In MCM GPU, primary GPU die shows total socket (primary + secondary) power information." << "\n"
+		    << "Secondary GPU die does not have any power information associated with it independently."<< "\n";
+	    rvs::lp::Log(msg_stream.str(), rvs::logresults);
+    }
+
     if(bjson){
         // add prelims for each action, dtype and target stress
         json_add_primary_fields();

--- a/include/gpu_util.h
+++ b/include/gpu_util.h
@@ -40,6 +40,7 @@ extern void gpu_get_all_device_id(std::vector<uint16_t>* pgpus_device_id);
 extern void gpu_get_all_node_id(std::vector<uint16_t>* pgpus_node_id);
 extern void gpu_get_all_domain_id(std::vector<uint16_t>* pgpus_domain_id,
                 std::map<std::pair<uint16_t, uint16_t> , uint16_t>& pgpus_dom_loc_map); 
+extern bool gpu_check_if_mcm_die (uint16_t device_id);
 
 namespace rvs {
 

--- a/src/gpu_util.cpp
+++ b/src/gpu_util.cpp
@@ -44,6 +44,17 @@ using std::vector;
 using std::string;
 using std::ifstream;
 
+/* No of GPU devices with MCM GPU */
+#define MAX_NUM_MCM_GPU 4
+
+/* Unique Device Ids of MCM GPUS */
+static const uint16_t mcm_gpu_device_id[MAX_NUM_MCM_GPU] = {
+	/* Aldebaran */
+	0x7408,
+	0x740C,
+	0x740F,
+	0x7410};
+
 int gpu_num_subdirs(const char* dirpath, const char* prefix) {
   int count = 0;
   DIR *dirp;
@@ -258,6 +269,25 @@ void gpu_get_all_domain_id(std::vector<uint16_t>* pgpus_domain_id,
     f_id.close();
     f_prop.close();
   }
+}
+
+/**
+ * @brief Check if the GPU is die (chiplet) in Multi-Core Module (MCM) GPU.
+ * @param device_id GPU Device ID
+ * @return true if GPU is die in MCM GPU, false if GPU is single die GPU.
+ **/
+bool gpu_check_if_mcm_die (uint16_t device_id) {
+
+  uint16_t i = 0;
+  bool mcm_die = false;
+  
+  for (i  = 0; i < MAX_NUM_MCM_GPU; i++) {
+    if(mcm_gpu_device_id[i] == device_id) {
+      mcm_die = true;
+      break;
+    }
+  }
+  return mcm_die;
 }
 
 /**


### PR DESCRIPTION
SWDEV-291318 : [MI200] RVS IET module does not report power on one of the cards

This additional logging will help to know if the GPU die/chiplet is in Multi-Chip Module (MCM) GPU.