### PR TITLE
Fix typo

### DIFF
--- a/REGRESSION.md
+++ b/REGRESSION.md
@@ -20,7 +20,7 @@ Results are written into $RVS_BUILD/regression/
 
 Before running the run_regression.py you first need to set the following
 environment variables for location of RVS source tree and build folders
-(ajdust for your particular clone):
+(adjust for your particular clone):
 
     export WB=/work/yourworkfolder
     export RVS=$WB/ROCmValidationSuite

--- a/babel.so/src/action.cpp
+++ b/babel.so/src/action.cpp
@@ -375,7 +375,7 @@ int mem_action::get_all_selected_gpus(void) {
 
         return -1;
     } else {
-      msg = "No devices match criteria from the test configuation.";
+      msg = "No devices match criteria from the test configuration.";
       rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }

--- a/edp.so/src/action.cpp
+++ b/edp.so/src/action.cpp
@@ -588,7 +588,7 @@ int edp_action::get_all_selected_gpus(void) {
 
         return -1;
     } else {
-      msg = "No devices match criteria from the test configuation.";
+      msg = "No devices match criteria from the test configuration.";
       rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }

--- a/gst.so/src/action.cpp
+++ b/gst.so/src/action.cpp
@@ -530,7 +530,7 @@ int gst_action::get_all_selected_gpus(void) {
 
         return -1;
     } else {
-      msg = "No devices match criteria from the test configuation.";
+      msg = "No devices match criteria from the test configuration.";
       rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }

--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -691,7 +691,7 @@ int iet_action::get_all_selected_gpus(void) {
         else 
             iet_res = -1;
     } else {
-          msg = "No devices match criteria from the test configuation.";
+          msg = "No devices match criteria from the test configuration.";
           rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
           iet_res = 1;
     }

--- a/mem.so/src/action.cpp
+++ b/mem.so/src/action.cpp
@@ -400,7 +400,7 @@ int mem_action::get_all_selected_gpus(void) {
 
         return -1;
     } else {
-      msg = "No devices match criteria from the test configuation.";
+      msg = "No devices match criteria from the test configuration.";
       rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }

--- a/pebb.so/src/action.cpp
+++ b/pebb.so/src/action.cpp
@@ -207,7 +207,7 @@ bool pebb_action::get_all_common_config_keys(void) {
 }
 
 /**
- * @brief Create thread objects based on action description in configuation
+ * @brief Create thread objects based on action description in configuration
  * file.
  *
  * Threads are created but are not started. Execution, one by one of parallel,
@@ -347,7 +347,7 @@ int pebb_action::create_threads() {
     if (bmatch_found) {
       diag = "No peers found";
     } else {
-      diag = "No devices match criteria from the test configuation";
+      diag = "No devices match criteria from the test configuration";
     }
     msg = "[" + action_name + "] pcie-bandwidth  " + diag;
     rvs::lp::Log(msg, rvs::logerror);

--- a/perf.so/src/action.cpp
+++ b/perf.so/src/action.cpp
@@ -529,7 +529,7 @@ int perf_action::get_all_selected_gpus(void) {
 
         return -1;
     } else {
-      msg = "No devices match criteria from the test configuation.";
+      msg = "No devices match criteria from the test configuration.";
       rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }

--- a/pqt.so/src/action.cpp
+++ b/pqt.so/src/action.cpp
@@ -319,7 +319,7 @@ bool pqt_action::get_all_common_config_keys(void) {
 }
 
 /**
- * @brief Create thread objects based on action description in configuation
+ * @brief Create thread objects based on action description in configuration
  * file.
  *
  * Threads are created but are not started. Execution, one by one of parallel,
@@ -589,7 +589,7 @@ int pqt_action::create_threads() {
       diag = "No peers found";
     } else {
       RVSTRACE_
-      diag = "No devices match criteria from the test configuation";
+      diag = "No devices match criteria from the test configuration";
     }
     RVSTRACE_
     msg = "[" + action_name + "] p2p-bandwidth " + diag;

--- a/regression/run_regression.py
+++ b/regression/run_regression.py
@@ -84,7 +84,7 @@ while True:
                 num_tries = num_tries + 1
             else:
                 restart = 0
-                if s.find('No GPU/peer combination matches criteria from test configuation') != -1:
+                if s.find('No GPU/peer combination matches criteria from the test configuration') != -1:
                     res.write("WARN: Testname " + confname + " : No GPU/peer - maybe a infrastucture issue\n")
                 else:
                     res.write("FAIL: Testname " + confname + " does not have RESULT field" + "\n")

--- a/rvs/src/rvsif0.cpp
+++ b/rvs/src/rvsif0.cpp
@@ -86,7 +86,7 @@ const char* rvs::if0::get_description(void) {
 }
 
 /**
- * @brief Returns short info on what configuaration properties (keys) are suppored
+ * @brief Returns short info on what configuration properties (keys) are supported
  *
  * @return pointer to C string holding configuration info
  *

--- a/smqt.so/src/action.cpp
+++ b/smqt.so/src/action.cpp
@@ -322,7 +322,7 @@ int smqt_action::run(void) {
   }
   if (!devid_found) {
     global_pass = false;
-    msg = "No devices match criteria from the test configuation.";
+    msg = "No devices match criteria from the test configuration.";
     rvs::lp::Err(msg, MODULE_NAME, action_name);
     return -1;
   }

--- a/src/gpu_util.cpp
+++ b/src/gpu_util.cpp
@@ -272,7 +272,7 @@ void gpu_get_all_domain_id(std::vector<uint16_t>* pgpus_domain_id,
 }
 
 /**
- * @brief Check if the GPU is die (chiplet) in Multi-Core Module (MCM) GPU.
+ * @brief Check if the GPU is die (chiplet) in Multi-Chip Module (MCM) GPU.
  * @param device_id GPU Device ID
  * @return true if GPU is die in MCM GPU, false if GPU is single die GPU.
  **/


### PR DESCRIPTION
I've also created [a branch to simplify the boolean determination.](https://github.com/Umio-Yasuno/ROCmValidationSuite/tree/bool)
`val == true` --> `val`
But since this is my first pull request, I'd like to just fix the typo.