### PR TITLE
Add compiler option "-O0" when ASAN is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,7 @@ set(RVS_BINTEST_FOLDER ${CMAKE_BINARY_DIR}/bintest)
 
 # Check if Address Sanitizer enabled.
 if(BUILD_ADDRESS_SANITIZER)
-  set(ASAN_CXX_FLAGS "-fsanitize=address  -shared-libasan")
+  set(ASAN_CXX_FLAGS "-fsanitize=address  -shared-libasan -O0")
   set(ASAN_LD_FLAGS "-fuse-ld=lld")
 endif()
 


### PR DESCRIPTION
SWDEV-303253 : [ROCmValidationSuite] Address Sanitizer not detecting memory leaks

Due to compiler optimizations, Address Sanitizer (ASAN) was not detecting memory leaks. 
When ASAN build is enabled, set "-O0" no optimization option for compiler. 