### PR TITLE
fixing include lookup issue

### DIFF
--- a/rvs/CMakeLists.txt
+++ b/rvs/CMakeLists.txt
@@ -119,7 +119,7 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 ## define include directories
-include_directories(./ ../ ${YAML_INC_DIR})
+include_directories(./ ../ ${YAML_INC_DIR} ${YAML_LIB_DIR}/include)
 ## define lib directories
 link_directories(${CMAKE_CURRENT_BINARY_DIR} ${RVS_LIB_DIR} ${ASAN_LIB_PATH})
 ## additional libraries


### PR DESCRIPTION
Recent changes in yaml-cpp removed dll.h from source
and creates it runtime ad puts in build folder. Because
of this, include lookup fails. addin build folder to include_directory.

reference : https://github.com/jbeder/yaml-cpp/commit/da1c8d360e6b9ba8f1bc291728263548a8e30698