### PR TITLE
Remove unused local variables.

### DIFF
--- a/gst.so/src/gst_worker.cpp
+++ b/gst.so/src/gst_worker.cpp
@@ -388,7 +388,7 @@ bool GSTWorker::check_gflops_violation(double gflops_interval) {
  * @return true if stress violations is less than max_violations, false otherwise
  */
 bool GSTWorker::do_gst_stress_test(int *error, std::string *err_description) {
-    uint16_t num_sgemm_ops = 0, num_gflops_violations = 0;
+    uint16_t num_sgemm_ops = 0;
     uint64_t total_milliseconds, log_interval_milliseconds;
     uint64_t start_time, end_time;
     double seconds_elapsed, gflops_interval;
@@ -498,6 +498,7 @@ void GSTWorker::run() {
 
     // let the GPU ramp-up and check the result
     bool ramp_up_success = do_gst_ramp(&error, &err_description);
+    /* Junaid : Why no check ? */
 
     // GPU was not able to do the processing (HIP/rocBlas error(s) occurred)
     if (error) {

--- a/gst.so/src/gst_worker.cpp
+++ b/gst.so/src/gst_worker.cpp
@@ -498,7 +498,6 @@ void GSTWorker::run() {
 
     // let the GPU ramp-up and check the result
     bool ramp_up_success = do_gst_ramp(&error, &err_description);
-    /* Junaid : Why no check ? */
 
     // GPU was not able to do the processing (HIP/rocBlas error(s) occurred)
     if (error) {

--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -375,20 +375,22 @@ bool iet_action::get_all_common_config_keys(void) {
  * 
  */
 
-void iet_action::hip_to_smi_indices(){
+void iet_action::hip_to_smi_indices(void) {
     int hip_num_gpu_devices;
     hipGetDeviceCount(&hip_num_gpu_devices);
     // map this to smi as only these are visible
     uint32_t smi_num_devices;
     uint64_t val_ui64;
     std::map<uint64_t, int> smi_map;
+
     rsmi_status_t err = rsmi_num_monitor_devices(&smi_num_devices);
     if( err == RSMI_STATUS_SUCCESS){
-	for(auto i = 0; i < smi_num_devices; ++i){
-	    err = rsmi_dev_pci_id_get(i, &val_ui64);
-	    smi_map.insert({val_ui64, i});
-	}
+        for(auto i = 0; i < smi_num_devices; ++i){
+            err = rsmi_dev_pci_id_get(i, &val_ui64);
+            smi_map.insert({val_ui64, i});
+        }
     }
+
     for (int i = 0; i < hip_num_gpu_devices; i++) {
         // get GPU device properties
         hipDeviceProp_t props;
@@ -397,10 +399,10 @@ void iet_action::hip_to_smi_indices(){
         // compute device location_id (needed to match this device
         // with one of those found while querying the pci bus
         uint16_t hip_dev_location_id =
-                ((((uint16_t) (props.pciBusID)) << 8) | (((uint16_t)(props.pciDeviceID)) << 3) );
-	if(smi_map.find(hip_dev_location_id) != smi_map.end()){
-		hip_to_smi_idxs.insert({i, smi_map[hip_dev_location_id]});
-	}
+            ((((uint16_t) (props.pciBusID)) << 8) | (((uint16_t)(props.pciDeviceID)) << 3) );
+        if(smi_map.find(hip_dev_location_id) != smi_map.end()){
+            hip_to_smi_idxs.insert({i, smi_map[hip_dev_location_id]});
+        }
     }
 }
 
@@ -416,34 +418,36 @@ bool iet_action::do_edp_test(map<int, uint16_t> iet_gpus_device_index) {
     int          gpuId;
     bool gpu_masking = false;    // if HIP_VISIBLE_DEVICES is set, this will be true
     int hip_num_gpu_devices;
+    unsigned int i = 0;
+    map<int, uint16_t>::iterator it;
+    uint32_t smi_num_devices;
+
     hipGetDeviceCount(&hip_num_gpu_devices);
 
     vector<IETWorker> workers(iet_gpus_device_index.size());
     for (;;) {
-        unsigned int i = 0;
-
-        map<int, uint16_t>::iterator it;
-
 
         if (property_wait != 0)  // delay iet execution
             sleep(property_wait);
 
         rsmi_init(0);
-	uint32_t smi_num_devices;
+
+        /* Junaid: Check again ? */
         rsmi_status_t err = rsmi_num_monitor_devices(&smi_num_devices);
-	if(smi_num_devices != hip_num_gpu_devices)
-		gpu_masking = true;
-	if(gpu_masking){  // this is the case when using HIP_VISIBLE_DEVICES variable to modify GPU visibility
-		// smi output wont be affected by the flag and hence indices should be appropriately used.
-		hip_to_smi_indices();
-	}
-	IETWorker::set_use_json(bjson);
+        if(smi_num_devices != hip_num_gpu_devices)
+            gpu_masking = true;
+        if(gpu_masking){  // this is the case when using HIP_VISIBLE_DEVICES variable to modify GPU visibility
+            // smi output wont be affected by the flag and hence indices should be appropriately used.
+            hip_to_smi_indices();
+        }
+
+        IETWorker::set_use_json(bjson);
         for (it = iet_gpus_device_index.begin(); it != iet_gpus_device_index.end(); ++it) {
-	    if(hip_to_smi_idxs.find(it->first) != hip_to_smi_idxs.end()){
-		workers[i].set_smi_device_index(hip_to_smi_idxs[it->first]);
-	    } else{
-		workers[i].set_smi_device_index(it->first);
-	    }
+            if(hip_to_smi_idxs.find(it->first) != hip_to_smi_idxs.end()){
+                workers[i].set_smi_device_index(hip_to_smi_idxs[it->first]);
+            } else{
+                workers[i].set_smi_device_index(it->first);
+            }
             gpuId = it->second;
             // set worker thread params
             workers[i].set_name(action_name);
@@ -470,7 +474,7 @@ bool iet_action::do_edp_test(map<int, uint16_t> iet_gpus_device_index) {
             workers[i].set_ldb_offset(iet_ldb_offset);
             workers[i].set_ldc_offset(iet_ldc_offset);
             workers[i].set_tp_flag(iet_tp_flag);
- 
+
             i++;
         }
 
@@ -563,7 +567,6 @@ bool iet_action::add_gpu_to_edpp_list(uint16_t dev_location_id, int32_t gpu_id,
 
     return false;
 }
-
 
 /**
  * @brief flushes target power and dtype fields to json file

--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -418,21 +418,20 @@ bool iet_action::do_edp_test(map<int, uint16_t> iet_gpus_device_index) {
     int          gpuId;
     bool gpu_masking = false;    // if HIP_VISIBLE_DEVICES is set, this will be true
     int hip_num_gpu_devices;
-    unsigned int i = 0;
-    map<int, uint16_t>::iterator it;
-    uint32_t smi_num_devices;
 
     hipGetDeviceCount(&hip_num_gpu_devices);
 
     vector<IETWorker> workers(iet_gpus_device_index.size());
     for (;;) {
+        unsigned int i = 0;
+        map<int, uint16_t>::iterator it;
 
         if (property_wait != 0)  // delay iet execution
             sleep(property_wait);
 
         rsmi_init(0);
 
-        /* Junaid: Check again ? */
+        uint32_t smi_num_devices;
         rsmi_status_t err = rsmi_num_monitor_devices(&smi_num_devices);
         if(smi_num_devices != hip_num_gpu_devices)
             gpu_masking = true;

--- a/iet.so/src/iet_worker.cpp
+++ b/iet.so/src/iet_worker.cpp
@@ -195,7 +195,6 @@ void IETWorker::blasThread(int gpuIdx,  uint64_t matrix_size, std::string  iet_o
 bool IETWorker::do_iet_power_stress(void) {
     std::chrono::time_point<std::chrono::system_clock> iet_start_time, end_time,
                                                         sampling_start_time;
-    uint64_t  power_sampling_iters = 0;
     uint64_t  total_time_ms;
     uint64_t  last_avg_power;
     string    msg;
@@ -294,7 +293,6 @@ bool IETWorker::do_iet_power_stress(void) {
  */
 void IETWorker::run() {
     string msg, err_description;
-    int error;
 
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
             std::to_string(gpu_id) + " start " + std::to_string(target_power);

--- a/pebb.so/src/action_run.cpp
+++ b/pebb.so/src/action_run.cpp
@@ -82,7 +82,6 @@ uint64_t time_diff(
  * */
 int pebb_action::run() {
   int sts;
-  int cnt = 0;
   string msg;
   std::chrono::time_point<std::chrono::system_clock> pebb_start_time;
   std::chrono::time_point<std::chrono::system_clock> pebb_end_time;

--- a/perf.so/src/perf_worker.cpp
+++ b/perf.so/src/perf_worker.cpp
@@ -155,14 +155,9 @@ void PERFWorker::log_interval_gflops(double gflops_interval) {
  */
 bool PERFWorker::do_perf_stress_test(int *error, std::string *err_description) {
     uint16_t num_gemm_ops = 0;
-    double total_milliseconds;
     double start_time, end_time;
-    double seconds_elapsed;
-    double gflops_interval = 0;
     double timetaken;
     string msg;
-    std::chrono::time_point<std::chrono::system_clock> perf_start_time,
-                                            perf_end_time, perf_log_interval_time;
 
     *error = 0;
     max_gflops = 0;

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -182,7 +182,8 @@ bool fetch_gpu_list(int hip_num_gpu_devices, map<int, uint16_t>& gpus_device_ind
 }
 
 
-int display_gpu_info(void){
+int display_gpu_info (void) {
+
   struct device_info {
     std::string bus;
     std::string name;
@@ -190,16 +191,17 @@ int display_gpu_info(void){
     int32_t gpu_id;
     int32_t device_id;
   };
+
   char buff[1024];
   int hip_num_gpu_devices;
-  bool amd_gpus_found = false;
   std::string errmsg = " No supported GPUs available.";
+  std::vector<device_info> gpu_info_list;
+
   hipGetDeviceCount(&hip_num_gpu_devices);
   if( hip_num_gpu_devices == 0){
     std::cout << std::endl << errmsg << std::endl;
     return 0;
   }
-  std::vector<device_info> gpu_info_list;
   for (int i = 0; i < hip_num_gpu_devices; i++) {
     hipDeviceProp_t props;
     hipGetDeviceProperties(&props, i);

--- a/src/rvsliblogger.cpp
+++ b/src/rvsliblogger.cpp
@@ -351,9 +351,8 @@ int rvs::logger::JsonStartNodeCreate(const char* Module, const char* Action) {
  *
  */
 
-int rvs::logger::JsonEndNodeCreate() {
+int rvs::logger::JsonEndNodeCreate(void) {
   std::string row{RVSINDENT};
-  int res;
   row += list_end + newline;
   row += RVSINDENT + node_end + newline;
   row += node_end;


### PR DESCRIPTION
SWDEV-304055
[ROCmValidationSuite] [Compiler Warnings] Unused variables "-Wunused-variable"

Remove unused local variables in functions to avoid compiler warnings.

This reverts commit 82e5bb53d76247b3e78a25c2eb11085cf80f8631.