### PR TITLE
Change value of ramp interval

### DIFF
--- a/rvs/conf/gst_stress_12_hrs.conf
+++ b/rvs/conf/gst_stress_12_hrs.conf
@@ -5,7 +5,7 @@ actions:
   parallel: true
   count: 1
   duration:  43200000
-  ramp_interval: 43200000
+  ramp_interval: 300000
   log_interval: 12000
   target_stress: 8000
   max_violations: 1

--- a/rvs/conf/gst_stress_3_hrs.conf
+++ b/rvs/conf/gst_stress_3_hrs.conf
@@ -5,7 +5,7 @@ actions:
   parallel: true
   count: 1
   duration:  10800000
-  ramp_interval: 10800000
+  ramp_interval: 300000
   log_interval: 6000
   target_stress: 8000
   max_violations: 1

--- a/rvs/conf/gst_stress_6_hrs.conf
+++ b/rvs/conf/gst_stress_6_hrs.conf
@@ -5,7 +5,7 @@ actions:
   parallel: true
   count: 1
   duration:  21600000
-  ramp_interval: 21600000
+  ramp_interval: 300000
   log_interval: 6000
   target_stress: 8000
   max_violations: 1


### PR DESCRIPTION
[SWDEV-325774] - 
Set ramp interval to 5 mins in 
1. gst_stress_12_hrs.conf
2. gst_stress_6_hrs.conf
3. gst_stress_3_hrs.conf
which will result in actual test duration almost equal to duration.