### PR TITLE
Upgrade Gtest to newer release

### DIFF
--- a/CMakeGtestDownload.cmake
+++ b/CMakeGtestDownload.cmake
@@ -30,7 +30,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.10.0
+  GIT_TAG           release-1.11.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
With latest GCC, under stricter rules like -Werror=maybe-uninitialized
some builds are failing, fix is available in GTest ,
https://github.com/google/googletest/pull/3024/files
So upgrading release to get those changes too