### PR TITLE
SWDEV-345870 - Correct HSA path for new directory layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,15 @@ else()
 endif()
 set(ROCM_SMI_LIB "rocm_smi64" CACHE STRING "rocm_smi library name")
 
+# Determine HSA_PATH
+if(NOT DEFINED HSA_PATH)
+     if(NOT DEFINED ENV{HSA_PATH})
+          set(HSA_PATH "${ROCM_PATH}" CACHE PATH "Path to which HSA runtime has been installed")
+     else()
+          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
+     endif()
+endif()
+
 set(RVS_BINTEST_FOLDER ${CMAKE_BINARY_DIR}/bintest)
 # Check if Address Sanitizer enabled.
 if(BUILD_ADDRESS_SANITIZER)

--- a/babel.so/CMakeLists.txt
+++ b/babel.so/CMakeLists.txt
@@ -55,15 +55,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/edp.so/CMakeLists.txt
+++ b/edp.so/CMakeLists.txt
@@ -88,15 +88,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/gm.so/CMakeLists.txt
+++ b/gm.so/CMakeLists.txt
@@ -86,15 +86,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/gpup.so/CMakeLists.txt
+++ b/gpup.so/CMakeLists.txt
@@ -85,15 +85,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/gst.so/CMakeLists.txt
+++ b/gst.so/CMakeLists.txt
@@ -88,15 +88,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-	     set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/iet.so/CMakeLists.txt
+++ b/iet.so/CMakeLists.txt
@@ -91,15 +91,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/mem.so/CMakeLists.txt
+++ b/mem.so/CMakeLists.txt
@@ -55,15 +55,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/pbqt.so/CMakeLists.txt
+++ b/pbqt.so/CMakeLists.txt
@@ -102,15 +102,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/pebb.so/CMakeLists.txt
+++ b/pebb.so/CMakeLists.txt
@@ -103,15 +103,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/peqt.so/CMakeLists.txt
+++ b/peqt.so/CMakeLists.txt
@@ -83,15 +83,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/perf.so/CMakeLists.txt
+++ b/perf.so/CMakeLists.txt
@@ -88,15 +88,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/pesm.so/CMakeLists.txt
+++ b/pesm.so/CMakeLists.txt
@@ -84,15 +84,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/rcqt.so/CMakeLists.txt
+++ b/rcqt.so/CMakeLists.txt
@@ -84,15 +84,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/rvs/CMakeLists.txt
+++ b/rvs/CMakeLists.txt
@@ -89,15 +89,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/rvslib/CMakeLists.txt
+++ b/rvslib/CMakeLists.txt
@@ -91,15 +91,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/smqt.so/CMakeLists.txt
+++ b/smqt.so/CMakeLists.txt
@@ -83,15 +83,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 

--- a/testif.so/CMakeLists.txt
+++ b/testif.so/CMakeLists.txt
@@ -84,15 +84,6 @@ if(NOT DEFINED HIPCC_PATH)
      endif()
 endif()
 
-# Determine HSA_PATH
-if(NOT DEFINED HSA_PATH)
-     if(NOT DEFINED ENV{HSA_PATH})
-          set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
-     else()
-          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
-     endif()
-endif()
-
 # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
 set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 


### PR DESCRIPTION
With file reorganization, HSA installed in /opt/rocm-ver Use the installed path rather than using backward compatibility path /opt/rocm-ver/hsa