### PR TITLE
Changes for removing rpath/runpath from binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,11 @@ set(ROCR_LIB_DIR "${ROCM_PATH}/lib" CACHE PATH "Contains library files exported 
 set(HIP_INC_DIR "${ROCM_PATH}" CACHE PATH "Contains header files exported by ROC Runtime")
 set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk" FORCE)
 
+# Changes for SWDEV-310152:
+# Since all public interface libraries are present in same folder
+# RPATH/RUNPATH is not required
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Disable Use Link Path" )
+set(CMAKE_SKIP_INSTALL_RPATH TRUE CACHE BOOL "Enable Skip install rpath" )
 
 #
 # If the user specifies -DCMAKE_BUILD_TYPE on the command line, take their


### PR DESCRIPTION
Summary of proposed changes:

- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package