### PR TITLE
Add support for Navi 32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,7 @@ if(BUILD_ADDRESS_SANITIZER)
   set(ASAN_LD_FLAGS "-fuse-ld=lld")
 endif()
 
-set(HCC_CXX_FLAGS  "-fno-gpu-rdc  --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908")
+set(HCC_CXX_FLAGS  "-fno-gpu-rdc  --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101")
 
 add_subdirectory(rvs)
 add_subdirectory(rvslib)


### PR DESCRIPTION
To generate code object for Navi32, else mem tests fail