### PR TITLE
Remove deprecated EDP module

### DIFF
--- a/rvs/.rvsmodules.config
+++ b/rvs/.rvsmodules.config
@@ -11,5 +11,4 @@ pebb: libpebb.so
 iet: libiet.so
 mem: libmem.so
 babel: libbabel.so
-edp: libedp.so
 perf: libperf.so


### PR DESCRIPTION
Reference to deprecated EDP module in .rvsmodules.config file has been removed.

