### PR TITLE
replace build.image with build.os in the .readthedocs.yaml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "samjwu"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,13 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: [htmlzip, pdf, epub]
 
 python:
-   version: "3.8"
    install:
    - requirements: docs/.sphinx/requirements.txt
+
+build:
+   os: ubuntu-22.04
+   tools:
+      python: "3.8"


### PR DESCRIPTION
https://docs.readthedocs.io/en/stable/config-file/v2.html

build.image (which is implicitly used if neither is specified) will be deprecated in October 2023