### PR TITLE
gfx941 & gfx942 arch. support in RVS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,7 @@ if(BUILD_ADDRESS_SANITIZER)
   set(ASAN_LD_FLAGS "-fuse-ld=lld")
 endif()
 
-set(HCC_CXX_FLAGS  "-fno-gpu-rdc  --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101 --offload-arch=gfx940")
+set(HCC_CXX_FLAGS "-fno-gpu-rdc --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942")
 
 add_subdirectory(rvslib)
 add_subdirectory(rvs)


### PR DESCRIPTION
RVS not build for gfx941 and gfx942. Currently, only build for gfx940.