### PR TITLE
Add ability to run external binary modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ add_subdirectory(mem.so)
 add_subdirectory(babel.so)
 add_subdirectory(perf.so)
 add_subdirectory(tst.so)
+add_subdirectory(runexternal.so)
 
 if (RVS_BUILD_TESTS)
   add_subdirectory(testif.so)

--- a/runexternal.so/CMakeLists.txt
+++ b/runexternal.so/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 # Determine Roc Runtime header files are accessible
 if(DEFINED RVS_ROCMSMI)
   if(NOT RVS_ROCMSMI EQUAL 1)
-    if(NOT EXISTS ${ROCBLAS_INC_DIR}/rocblas.h)
+    if(NOT EXISTS ${ROCBLAS_INC_DIR}/${ROCBLAS_MODULE_NM_PREFIX}rocblas.h)
     message("ERROR: rocBLAS headers can't be found under specified path. Please set ROCBLAS_INC_DIR path. Current value is : " ${ROCBLAS_INC_DIR})
     RETURN()
     endif()

--- a/runexternal.so/CMakeLists.txt
+++ b/runexternal.so/CMakeLists.txt
@@ -1,0 +1,182 @@
+################################################################################
+##
+## Copyright (c) 2018 ROCm Developer Tools
+##
+## MIT LICENSE:
+## Permission is hereby granted, free of charge, to any person obtaining a copy of
+## this software and associated documentation files (the "Software"), to deal in
+## the Software without restriction, including without limitation the rights to
+## use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+## of the Software, and to permit persons to whom the Software is furnished to do
+## so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in all
+## copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+## SOFTWARE.
+##
+################################################################################
+
+cmake_minimum_required ( VERSION 3.5.0 )
+if ( ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  message(FATAL "In-source build is not allowed")
+endif ()
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+set ( RVS "runexternal" )
+set ( RVS_PACKAGE "rvs-roct" )
+set ( RVS_COMPONENT "lib${RVS}" )
+set ( RVS_TARGET "${RVS}" )
+
+project ( ${RVS_TARGET} )
+
+message(STATUS "MODULE: ${RVS}")
+add_compile_options(-std=c++11)
+add_compile_options(-Wall )
+if (RVS_COVERAGE)
+  add_compile_options(-o0 -fprofile-arcs -ftest-coverage)
+  set(CMAKE_EXE_LINKER_FLAGS "--coverage")
+  set(CMAKE_SHARED_LINKER_FLAGS "--coverage")
+endif()
+
+## Set default module path if not already set
+if ( NOT DEFINED CMAKE_MODULE_PATH )
+    set ( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/" )
+endif ()
+
+## Include common cmake modules
+include ( utils )
+
+## Setup the package version.
+get_version ( "0.0.0" )
+
+set ( BUILD_VERSION_MAJOR ${VERSION_MAJOR} )
+set ( BUILD_VERSION_MINOR ${VERSION_MINOR} )
+set ( BUILD_VERSION_PATCH ${VERSION_PATCH} )
+set ( LIB_VERSION_STRING "${BUILD_VERSION_MAJOR}.${BUILD_VERSION_MINOR}.${BUILD_VERSION_PATCH}" )
+
+if ( DEFINED VERSION_BUILD AND NOT ${VERSION_BUILD} STREQUAL "" )
+    set ( BUILD_VERSION_PATCH "${BUILD_VERSION_PATCH}-${VERSION_BUILD}" )
+endif ()
+set ( BUILD_VERSION_STRING "${BUILD_VERSION_MAJOR}.${BUILD_VERSION_MINOR}.${BUILD_VERSION_PATCH}" )
+
+## make version numbers visible to C code
+add_compile_options(-DBUILD_VERSION_MAJOR=${VERSION_MAJOR})
+add_compile_options(-DBUILD_VERSION_MINOR=${VERSION_MINOR})
+add_compile_options(-DBUILD_VERSION_PATCH=${VERSION_PATCH})
+add_compile_options(-DLIB_VERSION_STRING="${LIB_VERSION_STRING}")
+add_compile_options(-DBUILD_VERSION_STRING="${BUILD_VERSION_STRING}")
+
+set(ROCBLAS_LIB "rocblas")
+set(HIP_HCC_LIB "amdhip64")
+
+# Determine HSA_PATH
+if(NOT DEFINED HIPCC_PATH)
+  if(NOT DEFINED ENV{HIPCC_PATH})
+    set(HIPCC_PATH "${ROCM_PATH}/hip" CACHE PATH "Path to which hipcc runtime has been installed")
+     else()
+       set(HIPCC_PATH $ENV{HIPCC_PATH} CACHE PATH "Path to which hipcc runtime has been installed")
+     endif()
+endif()
+
+# Determine HSA_PATH
+if(NOT DEFINED HSA_PATH)
+     if(NOT DEFINED ENV{HSA_PATH})
+	     set(HSA_PATH "${ROCM_PATH}/hsa" CACHE PATH "Path to which HSA runtime has been installed")
+     else()
+          set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
+     endif()
+endif()
+
+# Add HIP_VERSION to CMAKE_<LANG>_FLAGS
+set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
+
+set(HIP_HCC_BUILD_FLAGS)
+set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -fPIC ${HCC_CXX_FLAGS} -I${HSA_PATH}/include ${ASAN_CXX_FLAGS}")
+
+# Set compiler and compiler flags
+set(CMAKE_CXX_COMPILER "${HIPCC_PATH}/bin/hipcc")
+set(CMAKE_C_COMPILER   "${HIPCC_PATH}/bin/hipcc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${HIP_HCC_BUILD_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${HIP_HCC_BUILD_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_LD_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_LD_FLAGS}")
+
+if(BUILD_ADDRESS_SANITIZER)
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
+            OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
+  get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+endif()
+
+# Determine Roc Runtime header files are accessible
+if(NOT EXISTS ${HIP_INC_DIR}/include/hip/hip_runtime.h)
+  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_INC_DIR path. Current value is : " ${HIP_INC_DIR})
+  RETURN()
+endif()
+
+if(NOT EXISTS ${HIP_INC_DIR}/include/hip/hip_runtime_api.h)
+  message("ERROR: ROC Runtime headers can't be found under specified path. Please set HIP_INC_DIR path. Current value is : " ${HIP_INC_DIR})
+  RETURN()
+endif()
+
+# Determine Roc Runtime header files are accessible
+if(DEFINED RVS_ROCMSMI)
+  if(NOT RVS_ROCMSMI EQUAL 1)
+    if(NOT EXISTS ${ROCBLAS_INC_DIR}/rocblas.h)
+    message("ERROR: rocBLAS headers can't be found under specified path. Please set ROCBLAS_INC_DIR path. Current value is : " ${ROCBLAS_INC_DIR})
+    RETURN()
+    endif()
+
+    if(NOT EXISTS "${ROCBLAS_LIB_DIR}/lib${ROCBLAS_LIB}.so")
+      message("ERROR: rocBLAS library can't be found under specified path. Please set ROCBLAS_LIB_DIR path. Current value is : " ${ROCBLAS_LIB_DIR})
+      RETURN()
+    endif()
+  endif()
+endif()
+
+
+if(NOT EXISTS "${ROCR_LIB_DIR}/lib${HIP_HCC_LIB}.so")
+  message("ERROR: ROC Runtime libraries can't be found under specified path. Please set ROCR_LIB_DIR path. Current value is : " ${ROCR_LIB_DIR})
+  RETURN()
+endif()
+
+## define include directories
+include_directories(./ ../ ${ROCR_INC_DIR} ${ROCBLAS_INC_DIR} ${HIP_INC_DIR})
+# Add directories to look for library files to link
+link_directories(${RVS_LIB_DIR} ${ROCR_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ASAN_LIB_PATH})
+## additional libraries
+set (PROJECT_LINK_LIBS rvslib libpthread.so libpci.so libm.so)
+
+## define source files
+set(SOURCES src/rvs_module.cpp src/action.cpp src/runexternal_worker.cpp)
+
+## define target
+add_library( ${RVS_TARGET} SHARED ${SOURCES})
+set_target_properties(${RVS_TARGET} PROPERTIES
+        SUFFIX .so.${LIB_VERSION_STRING}
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+target_link_libraries(${RVS_TARGET} ${PROJECT_LINK_LIBS} ${HIP_HCC_LIB} ${ROCBLAS_LIB})
+add_dependencies(${RVS_TARGET} rvslib)
+
+add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+COMMAND ln -fs ./lib${RVS}.so.${LIB_VERSION_STRING} lib${RVS}.so.${VERSION_MAJOR} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+COMMAND ln -fs ./lib${RVS}.so.${VERSION_MAJOR} lib${RVS}.so WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+install(TARGETS ${RVS_TARGET} LIBRARY DESTINATION ${CMAKE_PACKAGING_INSTALL_PREFIX}/rvs COMPONENT rvsmodule)
+install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${RVS}.so.${VERSION_MAJOR}" DESTINATION ${CMAKE_PACKAGING_INSTALL_PREFIX}/rvs COMPONENT rvsmodule)
+install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${RVS}.so" DESTINATION ${CMAKE_PACKAGING_INSTALL_PREFIX}/rvs COMPONENT rvsmodule)
+
+# TEST SECTION
+#if (RVS_BUILD_TESTS)
+#  add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
+#  COMMAND ln -fs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib${RVS}.so.${VERSION_MAJOR} ${RVS_BINTEST_FOLDER}/lib${RVS}.so WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+#  )
+#  include(${CMAKE_CURRENT_SOURCE_DIR}/tests.cmake)
+#endif()

--- a/runexternal.so/include/action.h
+++ b/runexternal.so/include/action.h
@@ -38,7 +38,8 @@ extern "C" {
 #include <map>
 
 #include "include/rvsactionbase.h"
-
+#include "hip/hip_runtime.h"
+#include "hip/hip_runtime_api.h"
 using std::vector;
 using std::string;
 using std::map;

--- a/runexternal.so/include/action.h
+++ b/runexternal.so/include/action.h
@@ -1,0 +1,87 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef HIPTEST_SO_INCLUDE_ACTION_H_
+#define HIPTEST_SO_INCLUDE_ACTION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <pci/pci.h>
+#ifdef __cplusplus
+}
+#endif
+
+#include <vector>
+#include <string>
+#include <map>
+
+#include "include/rvsactionbase.h"
+
+using std::vector;
+using std::string;
+using std::map;
+
+/**
+ * @class runexternal_action
+ * @ingroup GST
+ *
+ * @brief GST action implementation class
+ *
+ * Derives from rvs::actionbase and implements actual action functionality
+ * in its run() method.
+ *
+ */
+class runexternal_action: public rvs::actionbase {
+ public:
+    runexternal_action();
+    virtual ~runexternal_action();
+
+    virtual int run(void);
+
+    std::string m_test_file_path;
+    std::string m_test_file_args;
+
+ protected:
+    //! TRUE if JSON output is required
+    bool bjson;
+
+    bool get_all_runexternal_config_keys(void);
+  /**
+  * @brief reads all common configuration keys from
+  * the module's properties collection
+  * @return true if no fatal error occured, false otherwise
+  */
+    bool get_all_common_config_keys(void);
+
+    int get_num_amd_gpu_devices(void);
+    bool start_runexternal_runners();
+  /**
+  * @brief gets the number of ROCm compatible AMD GPUs
+  * @return run number of GPUs
+  */
+    int run_external_tests();
+};
+
+#endif  // HIPTEST_SO_INCLUDE_ACTION_H_

--- a/runexternal.so/include/action.h
+++ b/runexternal.so/include/action.h
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018 ROCm Developer Tools
+ * Copyright (c) 2023 ROCm Developer Tools
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,8 +22,8 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#ifndef HIPTEST_SO_INCLUDE_ACTION_H_
-#define HIPTEST_SO_INCLUDE_ACTION_H_
+#ifndef RUNEXT_SO_INCLUDE_ACTION_H_
+#define RUNEXT_SO_INCLUDE_ACTION_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,9 +46,8 @@ using std::map;
 
 /**
  * @class runexternal_action
- * @ingroup GST
  *
- * @brief GST action implementation class
+ * @brief runexternal action implementation class
  *
  * Derives from rvs::actionbase and implements actual action functionality
  * in its run() method.
@@ -85,4 +84,4 @@ class runexternal_action: public rvs::actionbase {
     int run_external_tests();
 };
 
-#endif  // HIPTEST_SO_INCLUDE_ACTION_H_
+#endif  // RUNEXT_SO_INCLUDE_ACTION_H_

--- a/runexternal.so/include/runexternal_worker.h
+++ b/runexternal.so/include/runexternal_worker.h
@@ -28,7 +28,6 @@
 #include <string>
 #include <memory>
 #include "include/rvsthreadbase.h"
-#include "include/rvs_blas.h"
 #include "include/rvs_util.h"
 
 #define GST_RESULT_PASS_MESSAGE         "true"

--- a/runexternal.so/include/runexternal_worker.h
+++ b/runexternal.so/include/runexternal_worker.h
@@ -22,32 +22,30 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#ifndef HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_
-#define HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_
+#ifndef EXTTEST_SO_INCLUDE_EXTTEST_WORKER_H_
+#define EXTTEST_SO_INCLUDE_EXTTEST_WORKER_H_
 
 #include <string>
 #include <memory>
 #include "include/rvsthreadbase.h"
 #include "include/rvs_util.h"
 
-#define GST_RESULT_PASS_MESSAGE         "true"
-#define GST_RESULT_FAIL_MESSAGE         "false"
 
 
 /**
- * @class hipTestWorker
+ * @class runExtWorker
  * @ingroup GST
  *
- * @brief hipTestWorker action implementation class
+ * @brief runExtWorker action implementation class
  *
  * Derives from rvs::ThreadBase and implements actual action functionality
  * in its run() method.
  *
  */
-class hipTestWorker : public rvs::ThreadBase {
+class runExtWorker : public rvs::ThreadBase {
  public:
-    hipTestWorker();
-    virtual ~hipTestWorker();
+    runExtWorker();
+    virtual ~runExtWorker();
 
     //! sets action name
     void set_name(const std::string& name) { action_name = name; }
@@ -59,7 +57,7 @@ class hipTestWorker : public rvs::ThreadBase {
     void set_args(std::string args) { m_test_args = args; }
 
     const std::string& get_path(void) { return m_test_path; }
-    bool start_hip_tests(int &error, std::string &errdesc);
+    bool start_ext_tests(int &error, std::string &errdesc);
  protected:
     virtual void run(void);
  protected:
@@ -70,4 +68,4 @@ class hipTestWorker : public rvs::ThreadBase {
     std::string m_test_args;
 };
 
-#endif  // HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_
+#endif  // EXTTEST_SO_INCLUDE_EXTTEST_WORKER_H_

--- a/runexternal.so/include/runexternal_worker.h
+++ b/runexternal.so/include/runexternal_worker.h
@@ -1,0 +1,74 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_
+#define HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_
+
+#include <string>
+#include <memory>
+#include "include/rvsthreadbase.h"
+#include "include/rvs_blas.h"
+#include "include/rvs_util.h"
+
+#define GST_RESULT_PASS_MESSAGE         "true"
+#define GST_RESULT_FAIL_MESSAGE         "false"
+
+
+/**
+ * @class hipTestWorker
+ * @ingroup GST
+ *
+ * @brief hipTestWorker action implementation class
+ *
+ * Derives from rvs::ThreadBase and implements actual action functionality
+ * in its run() method.
+ *
+ */
+class hipTestWorker : public rvs::ThreadBase {
+ public:
+    hipTestWorker();
+    virtual ~hipTestWorker();
+
+    //! sets action name
+    void set_name(const std::string& name) { action_name = name; }
+    //! returns action name
+    const std::string& get_name(void) { return action_name; }
+
+    //! sets test path
+    void set_path(std::string pathname) { m_test_path = pathname; }
+    void set_args(std::string args) { m_test_args = args; }
+
+    const std::string& get_path(void) { return m_test_path; }
+    bool start_hip_tests(int &error, std::string &errdesc);
+ protected:
+    virtual void run(void);
+ protected:
+    //! name of the action
+    std::string action_name;
+    //! path to execute test
+    std::string m_test_path;
+    std::string m_test_args;
+};
+
+#endif  // HIPTEST_SO_INCLUDE_HIPTEST_WORKER_H_

--- a/runexternal.so/include/rvs_module.h
+++ b/runexternal.so/include/rvs_module.h
@@ -1,0 +1,31 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef HIPTEST_SO_INCLUDE_RVS_MODULE_H_
+#define HIPTEST_SO_INCLUDE_RVS_MODULE_H_
+
+#include "include/rvsliblog.h"
+
+
+#endif  // HIPTEST_SO_INCLUDE_RVS_MODULE_H_

--- a/runexternal.so/src/.gitignore
+++ b/runexternal.so/src/.gitignore
@@ -1,0 +1,1 @@
+/libmain.cpp

--- a/runexternal.so/src/action.cpp
+++ b/runexternal.so/src/action.cpp
@@ -55,7 +55,7 @@ using std::regex;
 #define FLOATING_POINT_REGEX            "^[0-9]*\\.?[0-9]+$"
 
 #define JSON_CREATE_NODE_ERROR          "JSON cannot create node"
-
+const std::string NOARGS{"None"};
 /**
  * @brief default class constructor
  */
@@ -117,7 +117,8 @@ bool runexternal_action::get_all_runexternal_config_keys(void) {
 	rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
 	bsts = false;
     }
-
+    if (m_test_file_args.compare(NOARGS) == 0)
+	    m_test_file_args = "";
     return bsts;
 }
 

--- a/runexternal.so/src/action.cpp
+++ b/runexternal.so/src/action.cpp
@@ -1,0 +1,221 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "include/action.h"
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <regex>
+#include <utility>
+#include <algorithm>
+#include <map>
+
+#define __HIP_PLATFORM_HCC__
+
+#include "include/rvs_key_def.h"
+#include "include/runexternal_worker.h"
+#include "include/rvsactionbase.h"
+#include "include/rvsloglp.h"
+
+using std::string;
+using std::vector;
+using std::map;
+using std::regex;
+
+#define MODULE_NAME                     "runexternal"
+#define MODULE_NAME_CAPS                "RUNEXTERNAL"
+#define RVS_CONF_RUNEXT_PATH_KEY       "test-path"
+#define RVS_CONF_RUNEXT_ARGS_KEY       "test-args"
+#define RUNEXT_DEFAULT_PATH            "tmp"
+#define RUNEXT_DEFAULT_ARGS            ""
+#define RUNEXT_NO_COMPATIBLE_GPUS          "No AMD compatible GPU found!"
+
+#define FLOATING_POINT_REGEX            "^[0-9]*\\.?[0-9]+$"
+
+#define JSON_CREATE_NODE_ERROR          "JSON cannot create node"
+
+/**
+ * @brief default class constructor
+ */
+runexternal_action::runexternal_action() {
+    bjson = false;
+}
+
+/**
+ * @brief class destructor
+ */
+runexternal_action::~runexternal_action() {
+    property.clear();
+}
+
+/**
+ * @brief runs the hip test session
+ * @return true if no error occured, false otherwise
+ */
+bool runexternal_action::start_runexternal_runners() {
+    size_t k = 0;
+    // one worker sufficient, as test runner
+    hipTestWorker worker;
+    worker.set_name(action_name);
+    worker.set_path(m_test_file_path);
+    worker.set_args(m_test_file_args);
+    worker.start();
+    worker.join();
+
+    return rvs::lp::Stopping() ? false : true;
+}
+
+/**
+ * @brief reads all GST-related configuration keys from
+ * the module's properties collection
+ * @return true if no fatal error occured, false otherwise
+ */
+bool runexternal_action::get_all_runexternal_config_keys(void) {
+    int error;
+    string msg;
+    bool bsts = true;
+
+    if (property_get<std::string>(RVS_CONF_RUNEXT_PATH_KEY, &m_test_file_path,
+            RUNEXT_DEFAULT_PATH)) {
+         msg = "invalid '" +
+         std::string(RVS_CONF_RUNEXT_PATH_KEY) + "' key value";
+         rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
+         bsts = false;
+    }
+    if (property_get<std::string>(RVS_CONF_RUNEXT_ARGS_KEY, &m_test_file_args,
+            RUNEXT_DEFAULT_ARGS)) {
+         msg = "invalid '" +
+         std::string(RVS_CONF_RUNEXT_PATH_KEY) + "' key value";
+         rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
+         bsts = false;
+    }
+
+    if(m_test_file_path == RUNEXT_DEFAULT_PATH){
+	msg = " hip test pat not specified";
+	rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
+	bsts = false;
+    }
+
+    return bsts;
+}
+
+/**
+ * @brief reads all common configuration keys from
+ * the module's properties collection
+ * @return true if no fatal error occured, false otherwise
+ */
+bool runexternal_action::get_all_common_config_keys(void) {
+    string msg, sdevid, sdev;
+    int error;
+    bool bsts = true;
+
+
+    // place holder for later
+
+    return bsts;
+}
+
+/**
+ * @brief gets the number of ROCm compatible AMD GPUs
+ * @return run number of GPUs
+ */
+int runexternal_action::get_num_amd_gpu_devices(void) {
+    int hip_num_gpu_devices;
+    string msg;
+
+    hipGetDeviceCount(&hip_num_gpu_devices);
+    if (hip_num_gpu_devices == 0) {  // no AMD compatible GPU
+        msg = action_name + " " + MODULE_NAME + " " + RUNEXT_NO_COMPATIBLE_GPUS;
+        rvs::lp::Log(msg, rvs::logerror);
+
+        if (bjson) {
+            unsigned int sec;
+            unsigned int usec;
+            rvs::lp::get_ticks(&sec, &usec);
+            void *json_root_node = rvs::lp::LogRecordCreate(MODULE_NAME,
+                            action_name.c_str(), rvs::loginfo, sec, usec, true);
+            if (!json_root_node) {
+                // log the error
+                string msg = std::string(JSON_CREATE_NODE_ERROR);
+                rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
+                return -1;
+            }
+
+            rvs::lp::AddString(json_root_node, "ERROR", RUNEXT_NO_COMPATIBLE_GPUS);
+            rvs::lp::LogRecordFlush(json_root_node, rvs::loginfo);
+        }
+        return 0;
+    }
+    return hip_num_gpu_devices;
+}
+
+/**
+ * @brief gets all selected GPUs and starts the worker threads
+ * @return run result
+ */
+int runexternal_action::run_external_tests(void) {
+    int hip_num_gpu_devices;
+    std::string msg;
+
+    hip_num_gpu_devices = get_num_amd_gpu_devices();
+     
+    if (hip_num_gpu_devices >= 1) {
+        if (start_runexternal_runners())
+            return 0;
+
+        return -1;
+    } else {
+      msg = "No devices match criteria from the test configuation.";
+      rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
+      return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief runs the whole GST logic
+ * @return run result
+ */
+int runexternal_action::run(void) {
+    string msg;
+
+    // get the action name
+    if (property_get(RVS_CONF_NAME_KEY, &action_name)) {
+      rvs::lp::Err("Action name missing", MODULE_NAME_CAPS);
+      return -1;
+    }
+
+    // check for -j flag (json logging)
+    if (property.find("cli.-j") != property.end())
+        bjson = true;
+
+    if (!get_all_common_config_keys())
+        return -1;
+    if (!get_all_runexternal_config_keys())
+        return -1;
+
+    return run_external_tests(); 
+}

--- a/runexternal.so/src/action.cpp
+++ b/runexternal.so/src/action.cpp
@@ -201,7 +201,6 @@ int runexternal_action::run_external_tests(void) {
  */
 int runexternal_action::run(void) {
     string msg;
-
     // get the action name
     if (property_get(RVS_CONF_NAME_KEY, &action_name)) {
       rvs::lp::Err("Action name missing", MODULE_NAME_CAPS);

--- a/runexternal.so/src/action.cpp
+++ b/runexternal.so/src/action.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018 ROCm Developer Tools
+ * Copyright (c) 2023 ROCm Developer Tools
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -71,13 +71,13 @@ runexternal_action::~runexternal_action() {
 }
 
 /**
- * @brief runs the hip test session
+ * @brief runs the runexternal session
  * @return true if no error occured, false otherwise
  */
 bool runexternal_action::start_runexternal_runners() {
     size_t k = 0;
     // one worker sufficient, as test runner
-    hipTestWorker worker;
+    runExtWorker worker;
     worker.set_name(action_name);
     worker.set_path(m_test_file_path);
     worker.set_args(m_test_file_args);
@@ -88,7 +88,7 @@ bool runexternal_action::start_runexternal_runners() {
 }
 
 /**
- * @brief reads all GST-related configuration keys from
+ * @brief reads all runexternal-related configuration keys from
  * the module's properties collection
  * @return true if no fatal error occured, false otherwise
  */
@@ -196,7 +196,7 @@ int runexternal_action::run_external_tests(void) {
 }
 
 /**
- * @brief runs the whole GST logic
+ * @brief runs the whole runexternal logic
  * @return run result
  */
 int runexternal_action::run(void) {

--- a/runexternal.so/src/runexternal_worker.cpp
+++ b/runexternal.so/src/runexternal_worker.cpp
@@ -1,0 +1,96 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "include/runexternal_worker.h"
+
+#include <unistd.h>
+#include <string>
+#include <memory>
+#include <iostream>
+#include "include/rvs_blas.h"
+#include "include/rvs_module.h"
+#include "include/rvsloglp.h"
+#include "include/rvs_util.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+
+#define MODULE_NAME                             "runexternal"
+
+using std::string;
+
+//bool hipTestWorker::bjson = false;
+
+hipTestWorker::hipTestWorker() {}
+hipTestWorker::~hipTestWorker() {}
+
+
+/**
+ * @brief performs the stress test on the given GPU
+ */
+void hipTestWorker::run() {
+    string msg, err_description;
+    int error = 0;
+
+
+    // log GST stress test - start message
+    msg = "[" + action_name + "] " + MODULE_NAME + " " +
+            " Starting the Hip test "; 
+    rvs::lp::Log(msg, rvs::logtrace);
+
+    // let the GPU ramp-up and check the result
+    bool hipsuccess = start_hip_tests(error, err_description);
+
+    // GPU was not able to do the processing (HIP/rocBlas error(s) occurred)
+    if (error) {
+        string msg = "[" + action_name + "] " + MODULE_NAME + " "
+                         + err_description;
+        rvs::lp::Log(msg, rvs::logerror);
+        return;
+    }
+
+}
+
+/**
+ * @brief forks and execs test result
+ * @param return true if test succeeded, false otherwise
+ */
+
+bool hipTestWorker::start_hip_tests(int &error, string &errdesc){
+    int pid, status;
+    auto found = m_test_path.find_last_of('/');
+    auto fname = m_test_path.substr(found+1);
+    if((pid = fork()) == 0){ // child
+	execl(m_test_path.c_str(), fname.c_str(), m_test_args.c_str(), 0);
+    }else{
+	waitpid(pid, &status, 0);
+	if (WIFEXITED(status)){
+	    error = 0;
+	    return true;
+	}
+	return false;
+    }
+}

--- a/runexternal.so/src/runexternal_worker.cpp
+++ b/runexternal.so/src/runexternal_worker.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <memory>
 #include <iostream>
+#include <fstream>
 #include "include/rvs_module.h"
 #include "include/rvsloglp.h"
 #include "include/rvs_util.h"
@@ -82,6 +83,14 @@ bool hipTestWorker::start_hip_tests(int &error, string &errdesc){
     int pid, status;
     auto found = m_test_path.find_last_of('/');
     auto fname = m_test_path.substr(found+1);
+    {
+      std::ifstream f(m_test_path.c_str());
+      if(! f.good()){
+	      error = -1;
+	      errdesc = "Binary file absent";
+	      return false;
+      }
+    }
     if((pid = fork()) == 0){ // child
 	execl(m_test_path.c_str(), fname.c_str(), m_test_args.c_str(), 0);
     }else{

--- a/runexternal.so/src/runexternal_worker.cpp
+++ b/runexternal.so/src/runexternal_worker.cpp
@@ -42,29 +42,26 @@
 
 using std::string;
 
-//bool hipTestWorker::bjson = false;
+//bool runExtWorker::bjson = false;
 
-hipTestWorker::hipTestWorker() {}
-hipTestWorker::~hipTestWorker() {}
+runExtWorker::runExtWorker() {}
+runExtWorker::~runExtWorker() {}
 
 
 /**
  * @brief performs the stress test on the given GPU
  */
-void hipTestWorker::run() {
+void runExtWorker::run() {
     string msg, err_description;
     int error = 0;
 
 
-    // log GST stress test - start message
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
-            " Starting the Hip test "; 
+            " Starting the external test " + m_test_path; 
     rvs::lp::Log(msg, rvs::logtrace);
 
-    // let the GPU ramp-up and check the result
-    bool hipsuccess = start_hip_tests(error, err_description);
+    bool status = start_ext_tests(error, err_description);
 
-    // GPU was not able to do the processing (HIP/rocBlas error(s) occurred)
     if (error) {
         string msg = "[" + action_name + "] " + MODULE_NAME + " "
                          + err_description;
@@ -79,7 +76,7 @@ void hipTestWorker::run() {
  * @param return true if test succeeded, false otherwise
  */
 
-bool hipTestWorker::start_hip_tests(int &error, string &errdesc){
+bool runExtWorker::start_ext_tests(int &error, string &errdesc){
     int pid, status;
     auto found = m_test_path.find_last_of('/');
     auto fname = m_test_path.substr(found+1);

--- a/runexternal.so/src/runexternal_worker.cpp
+++ b/runexternal.so/src/runexternal_worker.cpp
@@ -54,11 +54,12 @@ runExtWorker::~runExtWorker() {}
 void runExtWorker::run() {
     string msg, err_description;
     int error = 0;
-
-
+    auto pos = m_test_path.find_last_of('/');
+    string tname = (pos != std::string::npos) ? m_test_path.substr(pos+1) : "" ;
+    if (pos != std::string::npos)
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
-            " Starting the external test " + m_test_path; 
-    rvs::lp::Log(msg, rvs::logtrace);
+            " Starting :  " + tname; 
+    rvs::lp::Log(msg, rvs::loginfo);
 
     bool status = start_ext_tests(error, err_description);
 
@@ -68,6 +69,9 @@ void runExtWorker::run() {
         rvs::lp::Log(msg, rvs::logerror);
         return;
     }
+    msg = "[" + action_name + "] " + MODULE_NAME + " " +
+            " Completed running :  " + tname;
+    rvs::lp::Log(msg, rvs::loginfo);
 
 }
 

--- a/runexternal.so/src/runexternal_worker.cpp
+++ b/runexternal.so/src/runexternal_worker.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <memory>
 #include <iostream>
-#include "include/rvs_blas.h"
 #include "include/rvs_module.h"
 #include "include/rvsloglp.h"
 #include "include/rvs_util.h"

--- a/runexternal.so/src/rvs_module.cpp
+++ b/runexternal.so/src/rvs_module.cpp
@@ -1,0 +1,97 @@
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "include/rvs_module.h"
+#include "include/action.h"
+#include "include/rvsloglp.h"
+#include "include/gpu_util.h"
+
+/**
+ * @defgroup GST GST Module
+ *
+ * @brief performs GPU Stress Test
+ *
+ * The GPU Stress Test runs a Graphics Stress test or SGEMM/DGEMM
+ * (Single/Double-precision General Matrix Multiplication) workload
+ * on one, some or all GPUs. The GPUs can be of the same or different types.
+ * The duration of the benchmark should be configurable, both in terms of time
+ * (how long to run) and iterations (how many times to run).
+ * 
+ */
+
+extern "C" int rvs_module_has_interface(int iid) {
+  int sts = 0;
+  switch (iid) {
+  case 0:
+  case 1:
+    sts = 1;
+  }
+  return sts;
+}
+
+extern "C" const char* rvs_module_get_description(void) {
+    return "ROCm Validation Suite HipTest module";
+}
+
+extern "C" const char* rvs_module_get_config(void) {
+    return "test_path (string)" ;
+}
+
+extern "C" const char* rvs_module_get_output(void) {
+    return "pass (bool)";
+}
+
+extern "C" int rvs_module_init(void* pMi) {
+    rvs::lp::Initialize(static_cast<T_MODULE_INIT*>(pMi));
+    rvs::gpulist::Initialize();
+    return 0;
+}
+
+extern "C" int rvs_module_terminate(void) {
+    return 0;
+}
+
+extern "C" void* rvs_module_action_create(void) {
+    return static_cast<void*>(new runexternal_action);
+}
+
+extern "C" int   rvs_module_action_destroy(void* pAction) {
+    delete static_cast<rvs::actionbase*>(pAction);
+    return 0;
+}
+
+extern "C" int rvs_module_action_property_set(void* pAction, const char* Key,
+                                                            const char* Val) {
+    return static_cast<rvs::actionbase*>(pAction)->property_set(Key, Val);
+}
+
+extern "C" int rvs_module_action_callback_set(void* pAction,
+                                               rvs::callback_t callback,
+                                               void * user_param) {
+  return static_cast<rvs::actionbase*>(pAction)->callback_set(callback, user_param);
+}
+
+extern "C" int rvs_module_action_run(void* pAction) {
+    return static_cast<rvs::actionbase*>(pAction)->run();
+}

--- a/runexternal.so/tests.cmake
+++ b/runexternal.so/tests.cmake
@@ -1,0 +1,27 @@
+################################################################################
+##
+## Copyright (c) 2018 ROCm Developer Tools
+##
+## MIT LICENSE:
+## Permission is hereby granted, free of charge, to any person obtaining a copy of
+## this software and associated documentation files (the "Software"), to deal in
+## the Software without restriction, including without limitation the rights to
+## use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+## of the Software, and to permit persons to whom the Software is furnished to do
+## so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in all
+## copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+## SOFTWARE.
+##
+################################################################################
+
+
+include(tests_conf_logging)

--- a/rvs/.rvsmodules.config
+++ b/rvs/.rvsmodules.config
@@ -13,3 +13,4 @@ mem: libmem.so
 babel: libbabel.so
 perf: libperf.so
 tst: libtst.so
+runexternal: librunexternal.so

--- a/rvs/conf/runexternal.conf
+++ b/rvs/conf/runexternal.conf
@@ -1,0 +1,12 @@
+# Hip test
+#
+# Preconditions:
+#   sudo ./rvs -c conf/runexternal.conf -d 3
+#
+# Expected result:
+#   rus hip tests
+actions:
+- name: transferbench
+  module: runexternal
+  test-path: /home/amd/freyr/catch2/HIP/tests/catch/build/hipTestMain/UnitTests
+  test-args: 

--- a/rvs/conf/runexternal.conf
+++ b/rvs/conf/runexternal.conf
@@ -4,9 +4,9 @@
 #   sudo ./rvs -c conf/runexternal.conf -d 3
 #
 # Expected result:
-#   rus hip tests
+#   rus specified tests
 actions:
 - name: transferbench
   module: runexternal
-  test-path: /home/amd/freyr/catch2/HIP/tests/catch/build/hipTestMain/UnitTests
-  test-args: None
+  test-path: /home/master/manoj/experiments/transfer/TransferBench/TransferBench
+  test-args: p2p

--- a/rvs/conf/runexternal.conf
+++ b/rvs/conf/runexternal.conf
@@ -1,10 +1,12 @@
 # Hip test
 #
 # Preconditions:
+# test-path should have valid runnable executable and 
+# if test-args are not needed its value must be None
 #   sudo ./rvs -c conf/runexternal.conf -d 3
 #
 # Expected result:
-#   rus specified tests
+#   run specified tests
 actions:
 - name: transferbench
   module: runexternal

--- a/rvs/conf/runexternal.conf
+++ b/rvs/conf/runexternal.conf
@@ -9,4 +9,4 @@ actions:
 - name: transferbench
   module: runexternal
   test-path: /home/amd/freyr/catch2/HIP/tests/catch/build/hipTestMain/UnitTests
-  test-args: 
+  test-args: None


### PR DESCRIPTION
Til now, RVS runs only modules that are compiled as part of RVS code as shared objects , this module enables us to run pre compiled external binaries via conf file .
Can run one module at once via conf now. can modify test-path and test-args . 